### PR TITLE
docs(heimlern): ADRs für Explainability & Persistenz

### DIFF
--- a/docs/adr/0001-policy-explainability.md
+++ b/docs/adr/0001-policy-explainability.md
@@ -1,0 +1,17 @@
+# ADR-0001: Policy/Decision als Rust-Lib, Explainability (`why`)
+Status: Accepted
+Date: 2025-10-12
+
+## Kontext
+Entscheidungen sollen reproduzierbar und begründet sein.
+
+## Entscheidung
+- Rust-Lib (heimlern-core + -bandits).
+- Jede Decision hat `action`, `score`, `why`.
+
+## Konsequenzen
+- Klare Schnittstelle zu hausKI; leicht testbar.
+- `why` wird im Leitstand angezeigt.
+
+## Alternativen
+- Ad-hoc Heuristiken ohne Begründung: verworfen.

--- a/docs/adr/0002-policy-snapshot-persistenz.md
+++ b/docs/adr/0002-policy-snapshot-persistenz.md
@@ -1,0 +1,16 @@
+# ADR-0002: Policy-Snapshot-Persistenz (SQLite via hausKI)
+Status: Accepted
+Date: 2025-10-12
+
+## Kontext
+Lernen benötigt zustandsvolle Parameter.
+
+## Entscheidung
+- Snapshots (JSON) persistieren; Laden/Speichern via hausKI.
+
+## Konsequenzen
+- Wiederaufnahme nach Neustart möglich.
+- Migrationen über Versionsfeld.
+
+## Alternativen
+- Nur In-Memory: Verlust bei Neustart.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,6 @@
+# Architekturentscheidungsaufzeichnungen (ADR)
+
+## Index
+
+- [ADR-0001: Policy/Decision als Rust-Lib, Explainability (`why`)](0001-policy-explainability.md)
+- [ADR-0002: Policy-Snapshot-Persistenz (SQLite via hausKI)](0002-policy-snapshot-persistenz.md)


### PR DESCRIPTION
## Summary
- add index for architecture decision records
- document explainability-focused policy decision as ADR-0001
- capture policy snapshot persistence approach as ADR-0002

## Testing
- not run; docs-only changes

------
https://chatgpt.com/codex/tasks/task_e_68eb9244e69c832c9ca909d72a35a00f