### PR TITLE
Fix integrate_hauski example path

### DIFF
--- a/crates/heimlern-bandits/examples/integrate_hauski.rs
+++ b/crates/heimlern-bandits/examples/integrate_hauski.rs
@@ -1,9 +1,12 @@
-use heimlern_core::{Context,Policy};
 use heimlern_bandits::RemindBandit;
+use heimlern_core::{Context, Policy};
 
-fn main(){
+fn main() {
     let mut p = RemindBandit::default();
-    let ctx = Context{ kind: "reminder".into(), features: serde_json::json!({"load": 0.3}) };
+    let ctx = Context {
+        kind: "reminder".into(),
+        features: serde_json::json!({"load": 0.3}),
+    };
     let d = p.decide(&ctx);
     println!("{}", serde_json::to_string_pretty(&d).unwrap());
 }


### PR DESCRIPTION
## Summary
- move the integrate_hauski example into the heimlern-bandits crate so `cargo run --example` works from the workspace root
- format the example source for readability

## Testing
- cargo run --example integrate_hauski
- cargo test


------
https://chatgpt.com/codex/tasks/task_e_68edc8963b30832c9032b42483256837