### PR TITLE
heimlern: robustness + example + CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,4 +7,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo build --workspace --all-targets --verbose
-      - run: cargo test --workspace --verbose
+      - run: cargo clippy --workspace --all-targets -- -D warnings
+      - run: echo '{}' | cargo run -p heimlern-bandits --example decide
+      - run: cargo test --workspace --all-targets --verbose

--- a/README.md
+++ b/README.md
@@ -49,6 +49,14 @@ cargo run --example integrate_hauski
 
 Die Ausgabe enthält die gewählte Aktion, den Grund (Exploration oder Heuristik) und den in JSON serialisierten Kontext.
 
+Für schnelle Smoke-Tests des Banditen eignet sich außerdem das Beispiel `decide`. Es liest einen Kontext aus `stdin` (oder verwendet Defaults) und gibt die Entscheidung als JSON im [Policy-Schema](crates/heimlern-core/src/policy.rs) aus:
+
+```bash
+echo '{}' | cargo run -p heimlern-bandits --example decide
+```
+
+Ersetze `{}` durch einen gewünschten Kontext, um andere Slots oder Heuristiken zu prüfen.
+
 ## Weiterführende Dokumentation
 
 * [ADR-Index](docs/adr/README.md) – Übersicht und Motivation hinter den Architekturentscheidungen.

--- a/crates/heimlern-bandits/examples/decide.rs
+++ b/crates/heimlern-bandits/examples/decide.rs
@@ -1,0 +1,32 @@
+use std::io::{self, Read};
+
+use heimlern_bandits::RemindBandit;
+use heimlern_core::{Context, Policy};
+use serde_json::json;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut input = String::new();
+    io::stdin().read_to_string(&mut input)?;
+
+    let ctx = if input.trim().is_empty() {
+        Context {
+            kind: "reminder".into(),
+            features: json!({}),
+        }
+    } else {
+        serde_json::from_str::<Context>(&input).or_else(|_| {
+            serde_json::from_value(json!({
+                "kind": input.trim(),
+                "features": json!({}),
+            }))
+        })?
+    };
+
+    let mut policy = RemindBandit::default();
+    let decision = policy.decide(&ctx);
+
+    serde_json::to_writer_pretty(io::stdout(), &decision)?;
+    println!();
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- sanitize the RemindBandit by clamping epsilon and restoring default slots when missing
- extend unit coverage for snapshot round-trips and action prefixes while exposing a simple `decide` example
- tighten CI to run workspace tests across all targets
- add clippy linting and a smoke-test run of the `decide` example to the CI workflow
- document the `decide` example usage in the README for quick manual testing

## Testing
- `cargo test`
- `cargo clippy --workspace --all-targets -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_68ee60ef9600832c8e9e72184556b4a7