### PR TITLE
Guard validate-aussen workflow against missing JSONL files

### DIFF
--- a/.github/workflows/validate-aussen.yml
+++ b/.github/workflows/validate-aussen.yml
@@ -5,6 +5,7 @@ on: [push, pull_request, workflow_dispatch]
 jobs:
   samples:
     name: samples (data/samples/aussensensor.jsonl)
+    if: ${{ hashFiles('data/samples/aussensensor.jsonl') != '' }}
     uses: heimgewebe/metarepo/.github/workflows/reusable-validate-jsonl.yml@contracts-v1
     with:
       jsonl_path: data/samples/aussensensor.jsonl
@@ -14,6 +15,7 @@ jobs:
 
   fixtures:
     name: fixtures (tests/fixtures/aussen.jsonl)
+    if: ${{ hashFiles('tests/fixtures/aussen.jsonl') != '' }}
     uses: heimgewebe/metarepo/.github/workflows/reusable-validate-jsonl.yml@contracts-v1
     with:
       jsonl_path: tests/fixtures/aussen.jsonl


### PR DESCRIPTION
## Summary
- add guard conditions to the sample and fixture validation jobs so they only run when their JSONL files exist

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f3c142aa98832c99b03230cb550156