### PR TITLE
Clarify Decision score documentation

### DIFF
--- a/crates/heimlern-core/src/lib.rs
+++ b/crates/heimlern-core/src/lib.rs
@@ -25,7 +25,8 @@ pub struct Context {
 pub struct Decision {
     /// Die gewählte Aktion, typischerweise ein identifizierbarer Name oder Slot.
     pub action: String,
-    /// Heuristische Bewertung der Aktion im Bereich `0.0..=1.0`.
+    /// Heuristische Bewertung der Aktion. Policies können hier beliebige
+    /// numerische Werte verwenden (z. B. gemittelte Rewards ohne Begrenzung).
     pub score: f32,
     /// Erklärung, warum die Aktion gewählt wurde (z. B. "explore ε").
     pub why: String,


### PR DESCRIPTION
## Summary
- update the `Decision::score` documentation to reflect that policies may use values outside 0..=1

## Testing
- cargo test


------
https://chatgpt.com/codex/tasks/task_e_68f46b5fe968832c806dbf770f2221ed