### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 name: ci
 on: [push, pull_request]
+permissions:
+  contents: read
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/heimgewebe/heimlern/security/code-scanning/2](https://github.com/heimgewebe/heimlern/security/code-scanning/2)

To fix the issue, add a `permissions` block to the workflow to explicitly specify the minimum required privileges for the GITHUB_TOKEN. Since the job only builds, lints, and tests code and does not need to write to the repository or interact with issues, only `contents: read` is necessary. This can be added at the workflow root (to apply to all jobs), or at the job level for granularity. Here, we will add it at the root, directly below the `name:` or `on:` key.

No other code or functionality changes are required. Only the YAML block needs to be added.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
