### PR TITLE
Document policy lifecycle and add JSONL validation workflow

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -3,6 +3,7 @@
 Diese Verträge definieren das externe Austauschformat:
 - **PolicySnapshot**: Zustandsstand einer Policy (Arme, Zähler, Werte …)
 - **PolicyFeedback**: Rückmeldung zu einer Entscheidung (Reward, Notizen)
+- **Außensensor-Event**: Normalisierte JSON-Struktur für eingehende Sensor-Events
 
 Ziele:
 - Reproduzierbarkeit (Versionierung)

--- a/contracts/aussen_event.schema.json
+++ b/contracts/aussen_event.schema.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://heimlern.schemas/aussen-event.schema.json",
+  "title": "Außensensor-Event",
+  "description": "Normiertes Ereignis aus externen Sensoren oder Integrationen.",
+  "type": "object",
+  "required": ["type", "source"],
+  "additionalProperties": false,
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "Eindeutige Kennung des Events (frei wählbar)."
+    },
+    "type": {
+      "type": "string",
+      "description": "Kategorie des Events, z. B. 'link' oder 'note'."
+    },
+    "source": {
+      "type": "string",
+      "description": "Herkunft oder Integrationsquelle, z. B. 'sensor-hof'."
+    },
+    "title": {
+      "type": "string",
+      "description": "Optionaler Titel zur Anzeige."
+    },
+    "summary": {
+      "type": "string",
+      "description": "Kurzbeschreibung oder Erklärung zum Event."
+    },
+    "url": {
+      "type": "string",
+      "format": "uri",
+      "description": "Referenz-URL für weiterführende Informationen."
+    },
+    "tags": {
+      "type": "array",
+      "description": "Kategorisierende Tags.",
+      "items": {
+        "type": "string"
+      }
+    },
+    "ts": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Zeitstempel im ISO-8601-Format."
+    },
+    "features": {
+      "type": "object",
+      "description": "Beliebige strukturierte Zusatzinformationen.",
+      "additionalProperties": true
+    },
+    "meta": {
+      "type": "object",
+      "description": "Weitere Metadaten ohne feste Struktur.",
+      "additionalProperties": true
+    }
+  },
+  "examples": [
+    {
+      "type": "link",
+      "source": "sensor-hof",
+      "title": "Regenwarnung",
+      "url": "https://example.com/wetter",
+      "tags": ["regen", "sensor"],
+      "features": {
+        "level": 0.82
+      }
+    }
+  ]
+}

--- a/docs/policy-lifecycle.md
+++ b/docs/policy-lifecycle.md
@@ -1,4 +1,84 @@
 # Policy Lifecycle (Snapshot → Validate → Apply)
-1) Policy trifft Entscheidung auf Basis `Context`.
-2) Snapshot speichert Zustand als JSON (wiederaufnehmbar).
-3) Optional: Export als Event/Sample und Validierung gegen Contract.
+
+Dieser Leitfaden beschreibt den Lebenszyklus einer heimlern-Policy von der
+Zustandssicherung über die Schema-Validierung bis zur erneuten Aktivierung.
+Er ergänzt den Überblick im [README](../README.md) und fokussiert auf
+praktische Schritte, die mit den vorhandenen Werkzeugen wiederholt werden
+können.
+
+## 1. Snapshot erstellen
+
+1. Policy ausführen und Entscheidung treffen, z. B. über das Beispiel
+   `integrate_hauski`:
+   ```bash
+   cargo run --example integrate_hauski
+   ```
+2. Der Agent exportiert seinen Zustand als JSON-Snapshot über das
+   [`Policy`-Trait](../crates/heimlern-core/src/lib.rs) mit den Methoden
+   [`snapshot`](../crates/heimlern-core/src/lib.rs) und
+   [`load`](../crates/heimlern-core/src/lib.rs). Dadurch bleiben Zähler,
+   Zufalls-Seed und weitere Parameter zwischen Sessions erhalten.
+3. Für reproduzierbare Testdaten können die Beispielskripte verwendet werden:
+   ```bash
+   just snapshot:example
+   # legt /tmp/heimlern_snapshot.json an
+   ```
+
+Snapshots sind reine JSON-Dokumente, die keine Binärdaten enthalten und in
+Versionskontrolle oder Objektspeichern abgelegt werden können.
+
+## 2. Snapshot validieren
+
+1. Werkzeuge vorbereiten (Python-Venv und `jsonschema`):
+   ```bash
+   just venv
+   ```
+2. Automatisierte Prüfung mit dem vorhandenen Validator:
+   ```bash
+   python scripts/validate_json.py contracts/policy_snapshot.schema.json /tmp/heimlern_snapshot.json
+   ```
+   Alternativ validiert `just schema:validate` sowohl Snapshot als auch
+   Feedback-Beispiel in einem Lauf.
+3. Der Validator führt neben der JSON-Schema-Prüfung zusätzliche Konsistenz-
+   Checks aus, z. B. dass die Längen von `arms`, `counts` und `values`
+   übereinstimmen.
+
+Bei Validierungsfehlern bricht der Befehl mit Exit-Code ≠ 0 ab und nennt das
+betroffene Feld. Dadurch lassen sich Snapshots vor Deployments oder vor dem
+Import aus Drittquellen absichern.
+
+## 3. Snapshot anwenden
+
+1. Validiertes JSON in die Policy laden, typischerweise beim Start eines
+   Dienstes:
+   ```rust
+   let snapshot = serde_json::from_str::<serde_json::Value>(&json_str)?;
+   bandit.load(snapshot);
+   ```
+2. Anschließend kann die Policy unmittelbar wieder Entscheidungen treffen und
+   Feedback verarbeiten (`decide`/`feedback`).
+3. Im CI/CD-Kontext empfiehlt es sich, nach erfolgreicher Validierung den
+   Snapshot unter Versionskontrolle zu taggen oder in ein Artefakt-Repository
+   hochzuladen, um den Stand nachverfolgen zu können.
+
+## Validator-Workflow für JSONL-Samples
+
+Beispiel-Events (z. B. `data/samples/aussensensor.jsonl`) enthalten mehrere
+Dokumente im JSON-Lines-Format. Sie können direkt gegen den
+[Außensensor-Contract](../contracts/aussen_event.schema.json) geprüft werden:
+
+```bash
+python scripts/validate_json.py contracts/aussen_event.schema.json data/samples/aussensensor.jsonl
+```
+
+Der Validator liest jede Zeile, validiert sie einzeln und gibt ein ✓ je Zeile
+aus. Fehler werden mit Zeilennummer ausgewiesen, sodass defekte Events schnell
+gefunden und korrigiert werden können. Anschließend lassen sich die gleichen
+Samples z. B. über das Beispiel `ingest_events` einlesen:
+
+```bash
+cargo run -p heimlern-core --example ingest_events -- data/samples/aussensensor.jsonl
+```
+
+Damit steht für Sensorsamples der gleiche Qualitäts-Check zur Verfügung wie
+für Policy-Snapshots.


### PR DESCRIPTION
## Summary
- expand the policy lifecycle guide with actionable snapshot, validation, and apply steps plus JSONL validation instructions
- add an Außensensor event JSON schema and document it alongside the existing contracts
- extend the JSON validator script to process .jsonl inputs so sample events can be checked line by line

## Testing
- python scripts/examples.py
- python scripts/validate_json.py contracts/policy_snapshot.schema.json /tmp/heimlern_snapshot.json
- python scripts/validate_json.py contracts/policy_feedback.schema.json /tmp/heimlern_feedback.json
- python scripts/validate_json.py contracts/aussen_event.schema.json data/samples/aussensensor.jsonl


------
https://chatgpt.com/codex/tasks/task_e_68f600d7a87c832c92829af4a7baf6d4