### PR TITLE
Log bandit load/feedback issues, clarify event type naming, and stabilize comparisons

### DIFF
--- a/crates/heimlern-core/src/event.rs
+++ b/crates/heimlern-core/src/event.rs
@@ -20,10 +20,10 @@ pub struct AussenEvent {
     /// Eine eindeutige Kennung für dieses Ereignis, z. B. eine UUID.
     pub id: Option<String>,
     /// Der Typ des Ereignisses, der zur Kategorisierung dient (z. B.
-    /// "sensor.reading", "user.interaction"). Entspricht dem `type`-Feld in
-    /// JSON.
-    #[serde(rename = "type")]
-    pub kind: String,
+    /// "sensor.reading", "user.interaction").
+    /// Hinweis: Wir verwenden ein echtes Feld `type` via raw identifier,
+    /// damit Code und JSON-Name 1:1 übereinstimmen.
+    pub r#type: String,
     /// Die Quelle des Ereignisses (z. B. "haus-automation", "user-app").
     pub source: String,
     /// Ein optionaler, menschenlesbarer Titel für das Ereignis.


### PR DESCRIPTION
## Summary
- rename the `AussenEvent` type field to use a raw identifier that matches the JSON key without serde rename indirection
- emit warnings when bandit feedback actions lack the expected `remind.` prefix and when snapshots fail to load, with explanatory comments
- cover the feedback edge case with a unit test while documenting the snapshot fallback behavior
- use `f32::total_cmp` when selecting the best slot to avoid NaN-driven nondeterminism during exploitation

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_690367cbd2ac832c8a201ec45601d0db