### PR TITLE
Refactor: Make tracing a mandatory dependency

### DIFF
--- a/crates/heimlern-bandits/Cargo.toml
+++ b/crates/heimlern-bandits/Cargo.toml
@@ -11,12 +11,8 @@ serde_json = "1"
 rand = "0.8"
 heimlern-core = { path = "../heimlern-core" }
 thiserror = "1"
-tracing = { version = "0.1", optional = true }
+tracing = "0.1"
 time = { version = "0.3", features = ["formatting"] }
 
 [dev-dependencies]
 serde_json = "1"
-
-[features]
-# Aktiviert strukturiertes Logging; ohne dieses Feature wird zu STDERR geloggt.
-telemetry = ["tracing"]

--- a/crates/heimlern-bandits/src/lib.rs
+++ b/crates/heimlern-bandits/src/lib.rs
@@ -19,17 +19,9 @@ use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 
 // ---------------------------------
 // Kleiner Logging-Helper:
-// nutzt `tracing::warn!` falls Feature aktiv,
-// sonst fällt er auf eprintln! zurück.
+// nutzt `tracing::warn!`.
 fn log_warn(msg: &str) {
-    #[cfg(feature = "telemetry")]
-    {
-        tracing::warn!(target: "heimlern-bandits", "{msg}");
-    }
-    #[cfg(not(feature = "telemetry"))]
-    {
-        eprintln!("{msg}");
-    }
+    tracing::warn!(target: "heimlern-bandits", "{msg}");
 }
 
 const DEFAULT_SLOTS: &[&str] = &["morning", "afternoon", "evening"];


### PR DESCRIPTION
Removes the optional `telemetry` feature from the `heimlern-bandits` crate, making `tracing` a required dependency.

This simplifies the logging implementation by removing conditional compilation (`#[cfg]`) and ensuring that structured logging is always enabled. Consumers of the crate can now rely on a consistent logging interface.