### PR TITLE
feat: Make telemetry optional and add CI verification

### DIFF
--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -74,3 +74,37 @@ jobs:
 
       - name: test
         run: cargo test --workspace --all-targets --locked --no-fail-fast
+
+  test-with-telemetry:
+    runs-on: ubuntu-latest
+    needs: build-test
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+
+      - name: cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-stable-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-stable-
+            ${{ runner.os }}-cargo-
+
+      - name: cache target
+        uses: actions/cache@v4
+        with:
+          path: target
+          key: ${{ runner.os }}-target-stable-${{ hashFiles('**/Cargo.lock') }}-telemetry
+          restore-keys: |
+            ${{ runner.os }}-target-stable-
+
+      - name: test with telemetry feature
+        run: cargo test --workspace --all-targets --locked --no-fail-fast --features telemetry

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Siehe auch: **Policy-Lifecycle**: `docs/policy-lifecycle.md` und **Contracts** i
 5. [Weiterführende Dokumentation](#weiterführende-dokumentation)
 6. [Installation / Entwicklung](#installation--entwicklung)
 7. [Beitragen](#beitragen)
+8. [Optional: Telemetrie-Logging](#optional-telemetrie-logging)
 
 ## Schnellstart
 
@@ -64,33 +65,6 @@ echo '{}' | cargo run -p heimlern-bandits --example decide
 
 Ersetze `{}` durch einen gewünschten Kontext, um andere Slots oder Heuristiken zu prüfen.
 
-## Weiterführende Dokumentation
-
-* [ADR-Index](docs/adr/README.md) – Übersicht und Motivation hinter den Architekturentscheidungen.
-* Policy-Lifecycle: `docs/policy-lifecycle.md`
-* Inline-Rustdocs in den Crates (`cargo doc --open`) erläutern Strukturen, Traits und das Snapshot-Format im Detail.
-
-### Optional: Telemetry-Logging
-Mit dem Feature-Flag `telemetry` nutzt der Bandit strukturiertes Logging via [`tracing`](https://crates.io/crates/tracing).
-Für lokale Runs kannst du – etwa im Binary oder Beispiel – einen Subscriber setzen, um formatierte Ausgaben zu erhalten:
-
-```rust
-// main.rs (nur im Beispiel/Binary, nicht im lib)
-#[cfg(feature = "telemetry")]
-{
-    use tracing_subscriber::FmtSubscriber;
-    let _ = FmtSubscriber::builder()
-        .with_max_level(tracing::Level::WARN)
-        .try_init();
-}
-```
-
-Start:
-
-```bash
-cargo run -p heimlern-bandits --features telemetry --example decide
-```
-
 ### Beispiel: Außensensor-Events grob scoren
 
 ```bash
@@ -99,29 +73,11 @@ cargo run -p heimlern-core --example ingest_events -- data/samples/aussensensor.
 ```
 Die Ausgabe listet pro Zeile einen Score (0..1) und den Titel (falls vorhanden).
 
-### Optionale Features
+## Weiterführende Dokumentation
 
-#### Telemetrie
-
-Wenn das `telemetry`-Feature aktiviert ist, können Tracing-Informationen über `stdout` ausgegeben werden. Um dies in einer eigenen Anwendung zu nutzen, fügen Sie `tracing-subscriber` zu Ihren `[dependencies]` hinzu:
-
-```toml
-[dependencies]
-tracing-subscriber = "0.3"
-```
-
-Initialisieren Sie den Subscriber in Ihrer `main.rs`:
-
-```rust
-// nur im Beispiel/Binary, nicht im lib
-#[cfg(feature = "telemetry")]
-{
-    use tracing_subscriber::FmtSubscriber;
-    let _ = FmtSubscriber::builder()
-        .with_max_level(tracing::Level::WARN)
-        .try_init();
-}
-```
+* [ADR-Index](docs/adr/README.md) – Übersicht und Motivation hinter den Architekturentscheidungen.
+* Policy-Lifecycle: `docs/policy-lifecycle.md`
+* Inline-Rustdocs in den Crates (`cargo doc --open`) erläutern Strukturen, Traits und das Snapshot-Format im Detail.
 
 ## Installation / Entwicklung
 
@@ -140,20 +96,21 @@ cargo test  --workspace
 ## Beitragen
 Siehe [CONTRIBUTING.md](CONTRIBUTING.md).
 
-### Telemetrie-Logging (optional)
-Der Bandit kann strukturiert loggen, wenn das Feature `telemetry` aktiviert ist:
+## Optional: Telemetrie-Logging
 
+Das Feature `telemetry` aktiviert strukturiertes Logging via [`tracing`](https://docs.rs/tracing).
+Ohne das Feature wird zu `stderr` (`eprintln!`) geloggt.
+
+### Aktivieren
 ```bash
 cargo run -p heimlern-bandits --features telemetry --example decide
 ```
 
-In einem Binary/Beispiel kann optional ein Subscriber gesetzt werden:
+### Beispiel: Subscriber konfigurieren
+In einem Binary kann ein einfacher Subscriber gesetzt werden:
 ```rust
 #[cfg(feature = "telemetry")]
 {
-    use tracing_subscriber::FmtSubscriber;
-    let _ = FmtSubscriber::builder()
-        .with_max_level(tracing::Level::WARN)
-        .try_init();
+    tracing_subscriber::fmt().with_max_level(tracing::Level::WARN).init();
 }
 ```

--- a/crates/heimlern-bandits/Cargo.toml
+++ b/crates/heimlern-bandits/Cargo.toml
@@ -11,8 +11,14 @@ serde_json = "1"
 rand = "0.8"
 heimlern-core = { path = "../heimlern-core" }
 thiserror = "1"
-tracing = "0.1"
+tracing = { version = "0.1", optional = true }
 time = { version = "0.3", features = ["formatting"] }
 
 [dev-dependencies]
 serde_json = "1"
+
+[features]
+# Aktiviert strukturiertes Logging über `tracing::warn!`.
+# Ohne dieses Feature wird stattdessen `eprintln!` genutzt.
+default = []
+telemetry = ["tracing"]

--- a/crates/heimlern-bandits/src/lib.rs
+++ b/crates/heimlern-bandits/src/lib.rs
@@ -17,11 +17,19 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 
-// ---------------------------------
-// Kleiner Logging-Helper:
-// nutzt `tracing::warn!`.
+/// Logging-Helfer:
+/// Mit Feature `telemetry` → `tracing::warn!`, sonst → `eprintln!`.
+#[inline(always)]
 fn log_warn(msg: &str) {
-    tracing::warn!(target: "heimlern-bandits", "{msg}");
+    #[cfg(feature = "telemetry")]
+    {
+        use tracing::warn;
+        warn!(target: "heimlern-bandits", "{msg}");
+    }
+    #[cfg(not(feature = "telemetry"))]
+    {
+        eprintln!("[heimlern-bandits] {msg}");
+    }
 }
 
 const DEFAULT_SLOTS: &[&str] = &["morning", "afternoon", "evening"];


### PR DESCRIPTION
This change introduces an optional `telemetry` feature to the `heimlern-bandits` crate.

- The `tracing` dependency is now optional and enabled by the `telemetry` feature.
- A fallback logging mechanism using `eprintln!` is used when the feature is disabled.
- The `README.md` has been updated to document the new feature and its usage.
- A new job has been added to the CI workflow to run tests with the `telemetry` feature enabled, ensuring both build paths are continuously verified.