### PR TITLE
fix(bandits): Refactor redundant closure in test

### DIFF
--- a/crates/heimlern-bandits/src/lib.rs
+++ b/crates/heimlern-bandits/src/lib.rs
@@ -481,7 +481,7 @@ mod tests {
             None => panic!("Feld 'values' ist kein Array"),
         };
         assert_eq!(arms,   &vec!["x","y","z"].into_iter().map(|s| serde_json::Value::String(s.into())).collect::<Vec<_>>());
-        assert_eq!(counts, &vec![3,2,0].into_iter().map(|n| serde_json::Value::from(n)).collect::<Vec<_>>());
+        assert_eq!(counts, &vec![3,2,0].into_iter().map(serde_json::Value::from).collect::<Vec<_>>());
         // floats: 0.4, 0.0, 0.0
         let val1 = match values[0].as_f64() {
             Some(v) => v,


### PR DESCRIPTION
Replaced a redundant closure (`|n| f(n)`) with a direct function reference (`f`) in the `contract_snapshot_semantics_counts_values` test.

This change resolves a `clippy::redundant_closure` warning that was causing the build to fail due to the `-D warnings` flag.