### PR TITLE
The CI now correctly handles the telemetry feature as a crate-specifi…

### DIFF
--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -73,7 +73,8 @@ jobs:
       - name: Clippy lint (${{ matrix.features }})
         run: |
           if [ "${{ matrix.features }}" = "telemetry" ]; then
-            cargo clippy --workspace --all-targets --locked --features telemetry -- -D warnings
+            cargo clippy -p heimlern-bandits --all-targets --locked --features telemetry -- -D warnings
+            cargo clippy --workspace --exclude heimlern-bandits --all-targets --locked -- -D warnings
           else
             cargo clippy --workspace --all-targets --locked -- -D warnings
           fi
@@ -81,44 +82,17 @@ jobs:
       - name: Build workspace (${{ matrix.features }})
         run: |
           if [ "${{ matrix.features }}" = "telemetry" ]; then
-            cargo build --workspace --all-targets --locked --features telemetry
+            cargo build -p heimlern-bandits --all-targets --locked --features telemetry
+            cargo build --workspace --exclude heimlern-bandits --all-targets --locked
           else
             cargo build --workspace --all-targets --locked
           fi
 
       - name: test
-        run: cargo test --workspace --all-targets --locked --no-fail-fast
-
-  test-with-telemetry:
-    runs-on: ubuntu-latest
-    needs: build-test
-    steps:
-      - name: checkout
-        uses: actions/checkout@v4
-
-      - name: toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: stable
-
-      - name: cache cargo registry
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-          key: ${{ runner.os }}-cargo-stable-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-stable-
-            ${{ runner.os }}-cargo-
-
-      - name: cache target
-        uses: actions/cache@v4
-        with:
-          path: target
-          key: ${{ runner.os }}-target-stable-${{ hashFiles('**/Cargo.lock') }}-telemetry
-          restore-keys: |
-            ${{ runner.os }}-target-stable-
-
-      - name: test with telemetry feature
-        run: cargo test --workspace --all-targets --locked --no-fail-fast --features telemetry
+        run: |
+          if [ "${{ matrix.features }}" = "telemetry" ]; then
+            cargo test -p heimlern-bandits --all-targets --locked --no-fail-fast --features telemetry
+            cargo test --workspace --exclude heimlern-bandits --all-targets --locked --no-fail-fast
+          else
+            cargo test --workspace --all-targets --locked --no-fail-fast
+          fi


### PR DESCRIPTION
…c feature.

The CI workflow was applying the telemetry feature to the entire workspace, causing a build failure because only the heimlern-bandits crate has that feature. The solution is to be more specific and only apply the feature flag to the heimlern-bandits package.

The redundant `test-with-telemetry` job was also removed.