### PR TITLE
Refactor redundant closure in `default_slots`

### DIFF
--- a/crates/heimlern-bandits/src/lib.rs
+++ b/crates/heimlern-bandits/src/lib.rs
@@ -69,7 +69,7 @@ impl Default for RemindBandit {
 }
 
 fn default_slots() -> Vec<String> {
-    DEFAULT_SLOTS.iter().map(|s| (*s).to_string()).collect()
+    DEFAULT_SLOTS.iter().map(ToString::to_string).collect()
 }
 
 fn serialize_context(ctx: &Context) -> Option<serde_json::Value> {


### PR DESCRIPTION
The closure `|s| (*s).to_string()` in the `default_slots` function was flagged by the `redundant_closure` Clippy lint when building with `-D warnings`.

This commit replaces the closure with a direct method reference, `ToString::to_string`, which is functionally equivalent and more idiomatic. This resolves the linting error and allows the build to pass.