### PR TITLE
Fix Justfile syntax and remove duplicate default recipe

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,6 +1,6 @@
 set shell := ["bash","-eu","-o","pipefail","-c"]
 
-default: schema:validate
+default: schema-validate
 
 # ---- Python venv für Tools (jsonschema) ----
 venv:
@@ -9,23 +9,22 @@ venv:
 	. .venv/bin/activate && pip install -r requirements-tools.txt
 
 # ---- Beispiele schreiben ----
-snapshot:example:
+snapshot-example:
 	. .venv/bin/activate || true
 	python3 scripts/examples.py
 	@ls -l /tmp/heimlern_snapshot.json
 
-feedback:example:
+feedback-example:
 	. .venv/bin/activate || true
 	python3 scripts/examples.py
 	@ls -l /tmp/heimlern_feedback.json
 
 # ---- Validierung ----
-schema:validate: venv
+schema-validate: venv
 	. .venv/bin/activate && python scripts/examples.py
 	. .venv/bin/activate && python scripts/validate_json.py contracts/policy_snapshot.schema.json /tmp/heimlern_snapshot.json
 	. .venv/bin/activate && python scripts/validate_json.py contracts/policy_feedback.schema.json /tmp/heimlern_feedback.json
 	@echo "✓ alle Beispiel-Dokumente sind valide"
-default: lint
 lint:
     bash -n $(git ls-files *.sh *.bash)
     echo "lint ok"


### PR DESCRIPTION
- Renamed recipes to use hyphens instead of colons to avoid parsing errors.
- Removed a duplicate 'default' recipe that was causing a syntax error.