### PR TITLE
feat: Add workflow to validate policy decisions

### DIFF
--- a/.github/workflows/validate-decisions.yml
+++ b/.github/workflows/validate-decisions.yml
@@ -1,0 +1,47 @@
+name: validate-policy-decisions
+
+on:
+ push:
+ paths:
+ - "tests/fixtures/decision/**/*.json"
+ - ".github/workflows/validate-decisions.yml"
+ pull_request:
+ paths:
+ - "tests/fixtures/decision/**/*.json"
+ - ".github/workflows/validate-decisions.yml"
+ workflow_dispatch:
+
+jobs:
+ ajv-validate:
+ runs-on: ubuntu-latest
+ timeout-minutes: 5
+ steps:
+ - name: Checkout
+ uses: actions/checkout@v4
+
+ - name: Setup Node
+ uses: actions/setup-node@v4
+ with:
+ node-version: '20'
+
+ - name: Install ajv-cli
+ run: npm i -g ajv-cli@5
+
+ - name: Validate fixtures against policy.decision schema
+ shell: bash
+ run: |
+ set -euo pipefail
+ SCHEMA_URL="https://raw.githubusercontent.com/heimgewebe/metarepo/contracts-v1/contracts/policy.decision.schema.json"
+ curl -fsSL "$SCHEMA_URL" -o /tmp/policy.decision.schema.json
+ shopt -s nullglob
+ mapfile -t FILES < <(compgen -G "tests/fixtures/decision/**/*.json" || true)
+ if (( ${#FILES[@]} == 0 )); then
+ echo "::warning::No fixtures found under tests/fixtures/decision/"
+ exit 0
+ fi
+ for f in "${FILES[@]}"; do
+ echo "Validating $f"
+ ajv validate --spec=draft2020 --strict=true --validate-formats=true \
+ -s /tmp/policy.decision.schema.json -d "$f"
+ done
+ echo "✓ All fixtures valid."

--- a/tests/fixtures/decision/sample.ok.json
+++ b/tests/fixtures/decision/sample.ok.json
@@ -1,0 +1,17 @@
+{
+ "ts": "2025-01-01T12:00:00Z",
+ "policy": "reminder_time_selection",
+ "context": {
+ "source": "aussensensor",
+ "tags": ["calendar", "focus"],
+ "features": { "hour_local": 9, "has_conflict": false }
+ },
+ "candidates": ["now", "later_today", "tomorrow_morning"],
+ "action": "later_today",
+ "score": 0.73,
+ "why": "calendar_free_window & circadian_preference",
+ "meta": {
+ "model": "bandit:v0.3",
+ "exploration": 0.1
+ }
+}


### PR DESCRIPTION
Adds a new GitHub Actions workflow to validate policy decision fixtures against the JSON schema.

This workflow is triggered on changes to files in `tests/fixtures/decision/` or the workflow file itself. It uses `ajv-cli` to perform the validation.

A sample fixture is included to ensure the workflow can be tested.