### PR TITLE
Enable globstar in the validate-decisions workflow to ensure that top…

### DIFF
--- a/.github/workflows/validate-decisions.yml
+++ b/.github/workflows/validate-decisions.yml
@@ -33,6 +33,7 @@ jobs:
  set -euo pipefail
  SCHEMA_URL="https://raw.githubusercontent.com/heimgewebe/metarepo/contracts-v1/contracts/policy.decision.schema.json"
  curl -fsSL "$SCHEMA_URL" -o /tmp/policy.decision.schema.json
+ shopt -s globstar
  shopt -s nullglob
  mapfile -t FILES < <(compgen -G "tests/fixtures/decision/**/*.json" || true)
  if (( ${#FILES[@]} == 0 )); then


### PR DESCRIPTION
…-level fixture files are correctly identified and validated.

This commit fixes a bug in the validate-decisions workflow where the file globbing pattern '**/*.json' was not matching files at the top level of the 'tests/fixtures/decision/' directory. This was because the 'globstar' shell option was not enabled.

This change adds 'shopt -s globstar' to the workflow script to enable recursive globbing and ensure all fixture files are validated.