### PR TITLE
Fix: Correct ajv command in validate-decisions.yml

### DIFF
--- a/.github/workflows/validate-decisions.yml
+++ b/.github/workflows/validate-decisions.yml
@@ -18,8 +18,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "20"
-      - name: Show ajv version
-        run: npx --yes ajv-cli@5 --version
       - name: Validate fixtures
         env:
           SCHEMA_URL: https://raw.githubusercontent.com/heimgewebe/metarepo/contracts-v1/contracts/policy.decision.schema.json


### PR DESCRIPTION
Removed the "Show ajv version" step from the `validate-decisions.yml` workflow. This step was using the `--version` flag with `ajv-cli`, which is not a valid parameter for the `test` command and was causing the workflow to fail.