### PR TITLE
Fix globbing in decision validation workflow

### DIFF
--- a/.github/workflows/validate-decisions.yml
+++ b/.github/workflows/validate-decisions.yml
@@ -25,8 +25,8 @@ jobs:
           SCHEMA_URL: https://raw.githubusercontent.com/heimgewebe/metarepo/contracts-v1/contracts/policy.decision.schema.json
         run: |
           set -euo pipefail
-          shopt -s nullglob
-          mapfile -t FILES < <(compgen -G "tests/fixtures/decision/**/*.json" || true)
+          shopt -s globstar
+          FILES=(tests/fixtures/decision/**/*.json)
           if (( ${#FILES[@]} == 0 )); then
             echo "::notice::No decision fixtures found."
             exit 0


### PR DESCRIPTION
The `compgen` command with `globstar` was not correctly finding files in nested directories. This change updates the script to use a more direct bash array assignment with `globstar` enabled, ensuring that all test fixture files are correctly validated.