### PR TITLE
Fix(ci): Correct schema URL in validate-decisions workflow

### DIFF
--- a/.github/workflows/validate-decisions.yml
+++ b/.github/workflows/validate-decisions.yml
@@ -20,7 +20,7 @@ jobs:
           node-version: "20"
       - name: Validate fixtures
         env:
-          SCHEMA_URL: https://raw.githubusercontent.com/heimgewebe/metarepo/contracts-v1/contracts/policy.decision.schema.json
+          SCHEMA_URL: https://raw.githubusercontent.com/heimgewebe/metarepo/main/contracts/policy.decision.schema.json
         run: |
           set -euo pipefail
           shopt -s globstar


### PR DESCRIPTION
The previous URL was pointing to a non-existent branch (`contracts-v1`), causing the schema validation job to fail with a 404 error.

This commit updates the URL to point to the `main` branch, where the schema file is available.