### PR TITLE
The setup-node action in the validate-policy-decision workflow was mi…

### DIFF
--- a/.github/workflows/validate-policy-decision.yml
+++ b/.github/workflows/validate-policy-decision.yml
@@ -16,6 +16,8 @@ jobs:
 
       - name: Setup Node
         uses: actions/setup-node@5e221d4786ffb21088b21dfc9c80efb16b52cd3b # v4.0.2
+        with:
+          node-version: 20
 
       - name: Validate policy.decision fixtures (AJV)
         run: |


### PR DESCRIPTION
…ssing the required node-version input, causing the workflow to fail.

This commit adds the node-version input with a value of 20 to resolve the issue.