### PR TITLE
fix(ci): exclude intentionally invalid fixture from AJV validation

### DIFF
--- a/.github/workflows/validate-policy-decision.yml
+++ b/.github/workflows/validate-policy-decision.yml
@@ -33,7 +33,8 @@ jobs:
           SCHEMA_URL: https://raw.githubusercontent.com/heimgewebe/metarepo/contracts-v1/contracts/policy.decision.schema.json
         run: |
           set -euo pipefail
+          shopt -s extglob
           npx --yes ajv-cli@5 validate \
             --spec=draft2020 --all-errors --validate-formats=true --strict=true \
             -s "$SCHEMA_URL" \
-            -d "tests/fixtures/decision/*.json"
+            -d tests/fixtures/decision/!(*bad*).json


### PR DESCRIPTION
The new workflow validates every file under tests/fixtures/decision/*.json with ajv. The repository already contains sample.bad.json, which is purposely invalid. When this workflow runs it will always fail on that negative example, so any PR that touches fixtures or this workflow cannot pass CI. The job should skip the known-bad sample or validate only the fixtures expected to be valid.