### PR TITLE
feat(ci): add reusable workflow to check for @main references

### DIFF
--- a/.github/actions/check-main-refs/action.yml
+++ b/.github/actions/check-main-refs/action.yml
@@ -1,0 +1,12 @@
+name: 'Check for @main references in Actions'
+description: 'Checks for @main references in GitHub Actions workflow files.'
+runs:
+  using: 'composite'
+  steps:
+    - name: Check for @main references
+      run: |
+        if grep -r "@main" .github/workflows/; then
+          echo "Error: Found '@main' references in workflow files. Please use a specific commit SHA or tag."
+          exit 1
+        fi
+      shell: bash

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Check for @main references
+        uses: ./.github/actions/check-main-refs
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable


### PR DESCRIPTION
Adds a composite action to check for `@main` references in GitHub Actions workflows. This prevents the use of floating references to the main branch, which is a bad practice.

The initial implementation tried to use a reusable workflow as a step, which is not allowed. This has been corrected by using a composite action instead, which can be used as a step within a job.