### PR TITLE
Remove @main string from rust workflow step name

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - name: Check for @main references
+      - name: Check for main-branch action references
         uses: ./.github/actions/check-main-refs
       - uses: dtolnay/rust-toolchain@6d9817901c499d6b02debbb57edb38d33daa680b # stable
         with:


### PR DESCRIPTION
## Summary
- rename the rust workflow step that checks for main-branch references to avoid literal "@main" text

## Testing
- not run (not needed for workflow text change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6927fb9e3a38832c8727cf3703f8125a)