### PR TITLE
Add Heimgewebe organism context to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,3 +122,15 @@ In einem Binary kann ein einfacher Subscriber gesetzt werden:
     tracing_subscriber::fmt().with_max_level(tracing::Level::WARN).init();
 }
 ```
+
+## Organismus-Kontext
+
+Dieses Repository ist Teil des **Heimgewebe-Organismus**.
+
+Die übergeordnete Architektur, Achsen, Rollen und Contracts sind zentral beschrieben im  
+👉 [`metarepo/docs/heimgewebe-organismus.md`](https://github.com/heimgewebe/metarepo/blob/main/docs/heimgewebe-organismus.md)  
+sowie im Zielbild  
+👉 [`metarepo/docs/heimgewebe-zielbild.md`](https://github.com/heimgewebe/metarepo/blob/main/docs/heimgewebe-zielbild.md).
+
+Alle Rollen-Definitionen, Datenflüsse und Contract-Zuordnungen dieses Repos
+sind dort verankert.


### PR DESCRIPTION
## Summary
- add Heimgewebe organism context block to the README to reference the wider Heimgewebe organism

## Testing
- not run (documentation-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935588055d8832cbc85da23407ba848)