### PR TITLE
Fix decide example context parsing to keep features

### DIFF
--- a/crates/heimlern-bandits/examples/decide.rs
+++ b/crates/heimlern-bandits/examples/decide.rs
@@ -6,6 +6,52 @@ use serde::Serialize;
 use serde_json::{json, Value};
 use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 
+fn iso8601_now() -> String {
+    OffsetDateTime::now_utc()
+        .format(&Rfc3339)
+        .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_string())
+}
+
+fn parse_context(input: &str) -> Context {
+    if input.trim().is_empty() {
+        return Context {
+            kind: "reminder".into(),
+            features: json!({}),
+        };
+    }
+
+    if let Ok(ctx) = serde_json::from_str::<Context>(input) {
+        return ctx;
+    }
+
+    if let Ok(Value::Object(mut obj)) = serde_json::from_str::<Value>(input) {
+        let kind = obj
+            .remove("kind")
+            .and_then(|v| v.as_str().map(std::borrow::ToOwned::to_owned))
+            .unwrap_or_else(|| "reminder".to_string());
+
+        let features = match obj.remove("features") {
+            Some(value) => value,
+            None if obj.is_empty() => json!({}),
+            None => Value::Object(obj),
+        };
+
+        return Context { kind, features };
+    }
+
+    if let Ok(Value::String(kind)) = serde_json::from_str::<Value>(input) {
+        return Context {
+            kind,
+            features: json!({}),
+        };
+    }
+
+    Context {
+        kind: input.trim().into(),
+        features: json!({}),
+    }
+}
+
 #[derive(Serialize)]
 struct PolicyDecisionRecord {
     ts: String,
@@ -15,44 +61,11 @@ struct PolicyDecisionRecord {
     decision: Decision,
 }
 
-fn iso8601_now() -> String {
-    OffsetDateTime::now_utc()
-        .format(&Rfc3339)
-        .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_string())
-}
-
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut input = String::new();
     io::stdin().read_to_string(&mut input)?;
 
-    let ctx = if input.trim().is_empty() {
-        Context {
-            kind: "reminder".into(),
-            features: json!({}),
-        }
-    } else {
-        match serde_json::from_str::<Context>(&input) {
-            Ok(ctx) => ctx,
-            Err(_) => match serde_json::from_str::<Value>(&input) {
-                Ok(Value::Object(mut obj)) => {
-                    let kind = obj
-                        .remove("kind")
-                        .and_then(|v| v.as_str().map(std::borrow::ToOwned::to_owned))
-                        .unwrap_or_else(|| "reminder".to_string());
-                    let features = obj.remove("features").unwrap_or_else(|| json!({}));
-                    Context { kind, features }
-                }
-                Ok(Value::String(kind)) => Context {
-                    kind,
-                    features: json!({}),
-                },
-                _ => Context {
-                    kind: input.trim().into(),
-                    features: json!({}),
-                },
-            },
-        }
-    };
+    let ctx = parse_context(&input);
 
     let mut policy = RemindBandit::default();
     let mut decision = policy.decide(&ctx);
@@ -76,4 +89,27 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!();
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn keeps_remaining_fields_as_features_when_no_features_key() {
+        let ctx = parse_context(r#"{"kind":"reminder","foo":1,"bar":"baz"}"#);
+
+        assert_eq!(ctx.kind, "reminder");
+        assert_eq!(ctx.features["foo"], 1); // preserved from top-level map
+        assert_eq!(ctx.features["bar"], "baz");
+    }
+
+    #[test]
+    fn prefers_explicit_features_over_remaining_fields() {
+        let ctx = parse_context(r#"{"kind":"custom","features":{"x":true},"foo":1}"#);
+
+        assert_eq!(ctx.kind, "custom");
+        assert_eq!(ctx.features["x"], true); // features key wins
+        assert_eq!(ctx.features.get("foo"), None); // not duplicated
+    }
 }


### PR DESCRIPTION
## Summary
- preserve ad-hoc JSON fields as features when parsing input in the `decide` example
- extract context parsing into a helper and add regression tests for the fallback behavior

## Testing
- cargo test -q
- cargo test --examples -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69391d695b7c832cb69fc7ca8f03c7bf)