### PR TITLE
fix: realign heimlern contracts

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -7,7 +7,7 @@ on:
     - cron: "0 * * * *"
 
 env:
-  METRICS_SCHEMA_URL: https://raw.githubusercontent.com/heimgewebe/metarepo/contracts-v1/contracts/wgx/metrics.json
+  METRICS_SCHEMA_URL: https://raw.githubusercontent.com/heimgewebe/metarepo/main/contracts/metrics.snapshot.schema.json
   HAUSKI_POST_URL: ${{ secrets.HAUSKI_METRICS_URL }}
 
 jobs:
@@ -25,13 +25,13 @@ jobs:
 
       - name: Snapshot metrics
         run: bash scripts/wgx-metrics-snapshot.sh --json
-      - name: Fetch AJV schema (local file)
+      - name: Fetch AJV metrics schema
         run: |
           mkdir -p .ci
           curl -fsSL "$METRICS_SCHEMA_URL" -o .ci/metrics.schema.json
 
       - name: Validate metrics contract
-        run: npx --yes ajv-cli@5 validate -s .ci/metrics.schema.json -d metrics.json
+        run: npx --yes ajv-cli@5 validate --spec=draft2020 --strict=false -s .ci/metrics.schema.json -d metrics.json
 
       - name: Optional POST to hausKI
         if: ${{ env.HAUSKI_POST_URL && env.HAUSKI_POST_URL != '' }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -51,3 +51,11 @@ jobs:
           python scripts/validate_json.py \
           --schemas contracts/ \
           --samples data/samples/
+      - name: Validate weight adjustment fixture against metarepo contract
+        run: |
+          mkdir -p .ci
+          curl -fsSL https://raw.githubusercontent.com/heimgewebe/metarepo/main/contracts/policy.weight_adjustment.v1.schema.json \
+            -o .ci/policy.weight_adjustment.v1.schema.json
+          python scripts/validate_json.py \
+            .ci/policy.weight_adjustment.v1.schema.json \
+            tests/fixtures/feedback/adjustment.ok.json

--- a/crates/heimlern-bandits/README.md
+++ b/crates/heimlern-bandits/README.md
@@ -2,4 +2,4 @@
 
 This crate provides a simple ε-greedy bandit policy implementation for the `heimlern` project.
 
-Snapshots of the policy state now conform to the `contracts/policy_snapshot.schema.json` schema.
+Snapshots of the policy state now conform to the `contracts/policy.snapshot.schema.json` schema.

--- a/crates/heimlern-feedback/examples/feedback_analysis.rs
+++ b/crates/heimlern-feedback/examples/feedback_analysis.rs
@@ -96,9 +96,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             }
             if let Some(reasoning) = &proposal.reasoning {
                 println!("\n  Reasoning:");
-                for r in reasoning {
-                    println!("    • {}", r);
-                }
+                println!("    • {}", reasoning);
             }
 
             // Serialize to JSON (contract format)

--- a/crates/heimlern-feedback/src/lib.rs
+++ b/crates/heimlern-feedback/src/lib.rs
@@ -13,15 +13,15 @@
 //!
 //! *   [`DeltaValue::Absolute`]: "Set-to" semantics. The target parameter should be set exactly to this value.
 //!     Legacy consumers might have interpreted this as additive in the past, but the new standard distinguishes them.
-//! *   [`DeltaValue::Additive`]: "Delta" semantics. The value should be added to the current parameter.
 //! *   [`DeltaValue::Relative`]: Percentage change relative to the current value.
+//! *   [`DeltaValue::Additive`]: Legacy in-memory delta semantics for simulation-only callers. It is not emitted by v1 proposals.
 //!
 //! # Simulation
 //!
 //! This crate can simulate the expected impact of `epsilon` (exploration rate) adjustments using
 //! statistical re-weighting (mixture re-weighting). This requires decision outcomes to carry metadata about
 //! whether they were "explore" or "exploit" decisions. Simulation is supported for
-//! [`DeltaValue::Additive`] and [`DeltaValue::Absolute`] adjustments to `epsilon`.
+//! [`DeltaValue::Relative`], [`DeltaValue::Additive`], and [`DeltaValue::Absolute`] adjustments to `epsilon`.
 
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -50,8 +50,9 @@ const PATTERN_OVERALL_FAILURE_THRESHOLD: f32 = 0.5;
 // Adjustment thresholds
 /// Failure rate threshold (50%) that triggers exploration reduction
 const ADJUSTMENT_FAILURE_THRESHOLD: f32 = 0.5;
-/// Amount to reduce epsilon when failure rate is high
-const ADJUSTMENT_EPSILON_DELTA: f32 = -0.05;
+/// Contract-level percent delta used to reduce epsilon when failure rate is high.
+/// The simulator maps -5 percent to a -0.05 epsilon-fraction shift.
+const ADJUSTMENT_EPSILON_DELTA_PERCENT: f32 = -5.0;
 
 // Fallback constants
 /// Fallback timestamp when formatting fails
@@ -135,7 +136,7 @@ pub struct WeightAdjustmentProposal {
     pub evidence: Evidence,
     /// Human-readable explanations for the adjustments
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub reasoning: Option<Vec<String>>,
+    pub reasoning: Option<String>,
     /// Current status of this proposal
     #[serde(default)]
     pub status: ProposalStatus,
@@ -394,8 +395,9 @@ impl FeedbackAnalyzer {
         if overall_stats.failure_rate() > ADJUSTMENT_FAILURE_THRESHOLD {
             deltas.insert(
                 "epsilon".to_string(),
-                DeltaValue::Additive {
-                    value: ADJUSTMENT_EPSILON_DELTA,
+                DeltaValue::Relative {
+                    value: ADJUSTMENT_EPSILON_DELTA_PERCENT,
+                    unit: "percent".to_string(),
                 },
             );
             reasoning.push("Reduce exploration due to high failure rate".to_string());
@@ -403,14 +405,14 @@ impl FeedbackAnalyzer {
 
         // Simulate improvement using reweighting simulation
         let failure_rate_after_sim =
-            if let Some(DeltaValue::Additive { value }) = deltas.get("epsilon") {
-                1.0 - simulate_epsilon_change(outcomes, *value)
+            if let Some(DeltaValue::Relative { value, unit: _ }) = deltas.get("epsilon") {
+                1.0 - simulate_epsilon_change(outcomes, *value / 100.0)
             } else {
                 overall_stats.failure_rate()
             };
 
         Some(WeightAdjustmentProposal {
-            version: "0.1.0".to_string(),
+            version: "v1".to_string(),
             basis_policy: basis_policy.to_string(),
             ts: iso8601_now(),
             deltas,
@@ -422,7 +424,7 @@ impl FeedbackAnalyzer {
                 simulation_method: Some("reweight_epsilon_simulation".to_string()),
                 patterns: Some(patterns),
             },
-            reasoning: Some(reasoning),
+            reasoning: Some(reasoning.join("; ")),
             status: ProposalStatus::Proposed,
         })
     }
@@ -453,7 +455,13 @@ impl FeedbackAnalyzer {
             match val {
                 DeltaValue::Additive { value } => simulate_epsilon_change(outcomes, *value),
                 DeltaValue::Absolute { value } => simulate_epsilon_absolute(outcomes, *value),
-                _ => {
+                DeltaValue::Relative { value, unit } if unit == "percent" => {
+                    simulate_epsilon_change(outcomes, *value / 100.0)
+                }
+                DeltaValue::Relative { value, unit } if unit == "factor" => {
+                    simulate_epsilon_change(outcomes, *value - 1.0)
+                }
+                DeltaValue::Relative { .. } => {
                     let successes = outcomes.iter().filter(|o| outcome_is_success(o)).count();
                     ratio(successes, outcomes.len())
                 }
@@ -805,12 +813,18 @@ mod tests {
     #[test]
     fn proposal_serializes_to_valid_json() {
         let proposal = WeightAdjustmentProposal {
-            version: "0.1.0".to_string(),
+            version: "v1".to_string(),
             basis_policy: "test-policy".to_string(),
             ts: iso8601_now(),
             deltas: {
                 let mut map = HashMap::new();
-                map.insert("epsilon".to_string(), DeltaValue::Additive { value: -0.1 });
+                map.insert(
+                    "epsilon".to_string(),
+                    DeltaValue::Relative {
+                        value: -5.0,
+                        unit: "percent".to_string(),
+                    },
+                );
                 map
             },
             confidence: 0.68,
@@ -818,10 +832,10 @@ mod tests {
                 decisions_analyzed: 100,
                 failure_rate_before: Some(0.42),
                 failure_rate_after_sim: Some(0.31),
-                simulation_method: None,
+                simulation_method: Some("unit_test".to_string()),
                 patterns: Some(vec!["Test pattern".to_string()]),
             },
-            reasoning: Some(vec!["Test reasoning".to_string()]),
+            reasoning: Some("Test reasoning".to_string()),
             status: ProposalStatus::Proposed,
         };
 
@@ -857,7 +871,7 @@ mod tests {
         deltas.insert("epsilon".to_string(), DeltaValue::Additive { value: -0.1 });
 
         let proposal = WeightAdjustmentProposal {
-            version: "0.1.0".to_string(),
+            version: "legacy-simulation".to_string(),
             basis_policy: "test".to_string(),
             ts: iso8601_now(),
             deltas,
@@ -910,7 +924,7 @@ mod tests {
         deltas.insert("epsilon".to_string(), DeltaValue::Absolute { value: 0.4 });
 
         let proposal = WeightAdjustmentProposal {
-            version: "0.1.0".to_string(),
+            version: "v1".to_string(),
             basis_policy: "test".to_string(),
             ts: iso8601_now(),
             deltas,
@@ -953,7 +967,7 @@ mod tests {
         deltas.insert("epsilon".to_string(), DeltaValue::Absolute { value: 1.5 });
 
         let proposal = WeightAdjustmentProposal {
-            version: "0.1.0".to_string(),
+            version: "v1".to_string(),
             basis_policy: "test".to_string(),
             ts: iso8601_now(),
             deltas,
@@ -1005,7 +1019,7 @@ mod tests {
                 },
                 "recency.half_life": {
                     "kind": "relative",
-                    "value": -20.0,
+                    "value": -5.0,
                     "unit": "percent"
                 }
             },
@@ -1034,7 +1048,7 @@ mod tests {
         }
         if let Some(DeltaValue::Relative { value, unit }) = proposal.deltas.get("recency.half_life")
         {
-            assert!((value + 20.0).abs() < 1e-6);
+            assert!((value + 5.0).abs() < 1e-6);
             assert_eq!(unit, "percent");
         } else {
             panic!("Expected Relative delta for recency.half_life");
@@ -1137,7 +1151,7 @@ mod tests {
         deltas.insert("epsilon".to_string(), DeltaValue::Additive { value: 0.1 });
 
         let proposal = WeightAdjustmentProposal {
-            version: "0.1.0".to_string(),
+            version: "legacy-simulation".to_string(),
             basis_policy: "test".to_string(),
             ts: iso8601_now(),
             deltas,
@@ -1180,7 +1194,7 @@ mod tests {
         deltas.insert("epsilon".to_string(), DeltaValue::Additive { value: 10.0 });
 
         let proposal = WeightAdjustmentProposal {
-            version: "0.1.0".to_string(),
+            version: "legacy-simulation".to_string(),
             basis_policy: "test".to_string(),
             ts: iso8601_now(),
             deltas,
@@ -1214,7 +1228,7 @@ mod tests {
         let mut deltas = HashMap::new();
         deltas.insert("epsilon".to_string(), DeltaValue::Additive { value: -0.1 });
         let proposal = WeightAdjustmentProposal {
-            version: "0.1.0".to_string(),
+            version: "legacy-simulation".to_string(),
             basis_policy: "test".to_string(),
             ts: iso8601_now(),
             deltas,
@@ -1264,7 +1278,7 @@ mod tests {
         let mut deltas = HashMap::new();
         deltas.insert("epsilon".to_string(), DeltaValue::Additive { value: -0.1 });
         let proposal = WeightAdjustmentProposal {
-            version: "0.1.0".to_string(),
+            version: "legacy-simulation".to_string(),
             basis_policy: "test".to_string(),
             ts: iso8601_now(),
             deltas,

--- a/crates/heimlern-feedback/src/lib.rs
+++ b/crates/heimlern-feedback/src/lib.rs
@@ -50,8 +50,8 @@ const PATTERN_OVERALL_FAILURE_THRESHOLD: f32 = 0.5;
 // Adjustment thresholds
 /// Failure rate threshold (50%) that triggers exploration reduction
 const ADJUSTMENT_FAILURE_THRESHOLD: f32 = 0.5;
-/// Contract-level percent delta used to reduce epsilon when failure rate is high.
-/// The simulator maps -5 percent to a -0.05 epsilon-fraction shift.
+/// Contract-level relative percent delta used to reduce epsilon when failure rate is high.
+/// The simulator maps -5 percent to `current_epsilon * 0.95`, not to five percentage points.
 const ADJUSTMENT_EPSILON_DELTA_PERCENT: f32 = -5.0;
 
 // Fallback constants
@@ -405,12 +405,16 @@ impl FeedbackAnalyzer {
 
         // Simulate improvement using reweighting simulation
         let failure_rate_after_sim =
-            if let Some(DeltaValue::Relative { value, unit: _ }) = deltas.get("epsilon") {
-                1.0 - simulate_epsilon_change(outcomes, *value / 100.0)
+            if let Some(DeltaValue::Relative { value, unit }) = deltas.get("epsilon") {
+                let success_rate_after_sim = match unit.as_str() {
+                    "percent" => simulate_epsilon_relative(outcomes, 1.0 + (*value / 100.0)),
+                    "factor" => simulate_epsilon_relative(outcomes, *value),
+                    _ => overall_stats.success_rate(),
+                };
+                1.0 - success_rate_after_sim
             } else {
                 overall_stats.failure_rate()
             };
-
         Some(WeightAdjustmentProposal {
             version: "v1".to_string(),
             basis_policy: basis_policy.to_string(),
@@ -438,8 +442,12 @@ impl FeedbackAnalyzer {
     /// # Parameter Semantics
     ///
     /// *   **epsilon**:
-    ///     *   `DeltaValue::Additive`: Interpreted as a change to the exploration rate.
-    ///     *   `DeltaValue::Absolute`: Interpreted as setting the target exploration probability ($P(explore)$).
+    ///     *   `DeltaValue::Additive`: Legacy simulation-only change to the exploration rate.
+    ///     *   `DeltaValue::Absolute`: Sets the target exploration probability (`P(explore)`).
+    ///     *   `DeltaValue::Relative { unit: "percent" }`: Scales the current exploration fraction
+    ///         by `1.0 + value / 100.0`.
+    ///     *   `DeltaValue::Relative { unit: "factor" }`: Scales the current exploration fraction
+    ///         by `value`.
     #[must_use]
     pub fn simulate_adjustment(
         &self,
@@ -456,10 +464,10 @@ impl FeedbackAnalyzer {
                 DeltaValue::Additive { value } => simulate_epsilon_change(outcomes, *value),
                 DeltaValue::Absolute { value } => simulate_epsilon_absolute(outcomes, *value),
                 DeltaValue::Relative { value, unit } if unit == "percent" => {
-                    simulate_epsilon_change(outcomes, *value / 100.0)
+                    simulate_epsilon_relative(outcomes, 1.0 + (*value / 100.0))
                 }
                 DeltaValue::Relative { value, unit } if unit == "factor" => {
-                    simulate_epsilon_change(outcomes, *value - 1.0)
+                    simulate_epsilon_relative(outcomes, *value)
                 }
                 DeltaValue::Relative { .. } => {
                     let successes = outcomes.iter().filter(|o| outcome_is_success(o)).count();
@@ -610,6 +618,31 @@ fn simulate_epsilon_change(outcomes: &[DecisionOutcome], epsilon_delta: f32) -> 
 
     let current_explore_fraction = ratio(explore_stats.total, known_total);
     let new_explore_fraction = current_explore_fraction + epsilon_delta;
+
+    simulate_reweighting(
+        &exploit_stats,
+        &explore_stats,
+        &unknown_stats,
+        new_explore_fraction,
+    )
+}
+
+/// Estimates the success rate if epsilon were changed by a relative multiplier.
+fn simulate_epsilon_relative(outcomes: &[DecisionOutcome], multiplier: f32) -> f32 {
+    let (exploit_stats, explore_stats, unknown_stats) = collect_strategy_stats(outcomes);
+
+    let known_total = exploit_stats.total + explore_stats.total;
+    if known_total == 0 {
+        return ratio(unknown_stats.successes, unknown_stats.total);
+    }
+
+    let multiplier = if multiplier.is_finite() {
+        multiplier
+    } else {
+        1.0
+    };
+    let current_explore_fraction = ratio(explore_stats.total, known_total);
+    let new_explore_fraction = current_explore_fraction * multiplier;
 
     simulate_reweighting(
         &exploit_stats,
@@ -895,6 +928,51 @@ mod tests {
             "Sim: {:?} Expected: {:?}",
             simulated_rate,
             expected
+        );
+    }
+
+    #[test]
+    fn simulation_relative_percent_scales_current_explore_fraction() {
+        let analyzer = FeedbackAnalyzer::default();
+        let outcomes: Vec<DecisionOutcome> = (0..20)
+            .map(|i| {
+                let is_exploit = i % 2 == 0;
+                let strategy = if is_exploit { "exploit" } else { "explore ε" };
+                create_outcome(
+                    &i.to_string(),
+                    "action",
+                    is_exploit,
+                    if is_exploit { 1.0 } else { 0.0 },
+                    Some(strategy),
+                )
+            })
+            .collect();
+
+        let mut deltas = HashMap::new();
+        deltas.insert(
+            "epsilon".to_string(),
+            DeltaValue::Relative {
+                value: -5.0,
+                unit: "percent".to_string(),
+            },
+        );
+
+        let proposal = WeightAdjustmentProposal {
+            version: "v1".to_string(),
+            basis_policy: "test".to_string(),
+            ts: iso8601_now(),
+            deltas,
+            confidence: 0.7,
+            evidence: Evidence::default(),
+            reasoning: None,
+            status: ProposalStatus::Proposed,
+        };
+
+        let simulated_rate = analyzer.simulate_adjustment(&proposal, &outcomes);
+        let expected = 0.525;
+        assert!(
+            (simulated_rate - expected).abs() < 1e-5,
+            "Expected relative percent scaling to yield {expected}, got {simulated_rate}"
         );
     }
 

--- a/docs/learning-cycle.md
+++ b/docs/learning-cycle.md
@@ -80,7 +80,7 @@ if let Some(proposal) = analyzer.propose_adjustment("remind-bandit-v1", &outcome
     // - deltas: HashMap<String, DeltaValue>
     // - confidence: f32 (0.0..1.0)
     // - evidence: { decisions_analyzed, failure_rates, patterns }
-    // - reasoning: Vec<String>
+    // - reasoning: String
     // - status: Proposed
     
     // Exportiere als JSON

--- a/docs/policy-lifecycle.md
+++ b/docs/policy-lifecycle.md
@@ -35,7 +35,7 @@ Versionskontrolle oder Objektspeichern abgelegt werden können.
    ```
 2. Automatisierte Prüfung mit dem vorhandenen Validator:
    ```bash
-   python scripts/validate_json.py contracts/policy_snapshot.schema.json /tmp/heimlern_snapshot.json
+   python scripts/validate_json.py contracts/policy.snapshot.schema.json /tmp/heimlern_snapshot.json
    ```
    Alternativ validiert `just schema-validate` sowohl Snapshot als auch
    Feedback-Beispiel in einem Lauf.

--- a/scripts/validate_json.py
+++ b/scripts/validate_json.py
@@ -3,7 +3,7 @@
 Kleiner Validator für heimlern-Contracts.
 Verwendung:
   # Einzelne Datei validieren:
-  python scripts/validate_json.py contracts/policy_snapshot.schema.json /path/to/doc.json
+  python scripts/validate_json.py contracts/policy.snapshot.schema.json /path/to/doc.json
 
   # Batch-Validierung (CI-Modus):
   python scripts/validate_json.py --schemas contracts/ --samples data/samples/
@@ -75,6 +75,7 @@ SCHEMA_MAPPING = {
     "policy.decision.sample.jsonl": "policy.decision.schema.json",
     "policy.snapshot.sample.json": "policy.snapshot.schema.json",
     "policy.feedback.sample.json": "policy.feedback.schema.json",
+    "foreign-aussensensor.jsonl": "aussen.event.schema.json",
 }
 
 

--- a/tests/fixtures/feedback/adjustment.ok.json
+++ b/tests/fixtures/feedback/adjustment.ok.json
@@ -1,15 +1,16 @@
 {
-  "version": "0.1.0",
+  "version": "v1",
   "basis_policy": "remind-bandit-v1",
   "ts": "2026-01-04T12:00:00Z",
   "deltas": {
     "epsilon": {
-      "kind": "absolute",
-      "value": -0.05
+      "kind": "relative",
+      "value": -5.0,
+      "unit": "percent"
     },
     "recency.half_life": {
       "kind": "relative",
-      "value": -20.0,
+      "value": -5.0,
       "unit": "percent"
     }
   },
@@ -18,14 +19,12 @@
     "decisions_analyzed": 143,
     "failure_rate_before": 0.42,
     "failure_rate_after_sim": 0.31,
+    "simulation_method": "fixture",
     "patterns": [
       "High failure rate for remind.morning",
       "Trust level low shows systematic errors"
     ]
   },
-  "reasoning": [
-    "Reduce exploration due to high failure rate",
-    "Adjust recency bias based on temporal patterns"
-  ],
+  "reasoning": "Reduce exploration due to high failure rate; Adjust recency bias based on temporal patterns",
   "status": "proposed"
 }


### PR DESCRIPTION
Ready for merge. Head 6b4e13b fixes the relative epsilon semantics, adds a regression test, and keeps the existing contract realignment scope. Verified: GitHub checks pass, local Rust format, workspace tests, clippy, telemetry feature test, sample JSON validation, and weight-adjustment fixture validation pass. Follow-up later: pin metarepo contract refs.