### PR TITLE
feat: add operator routing learning contracts

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -24,6 +24,8 @@ schema-validate: venv
 	. .venv/bin/activate && python scripts/examples.py
 	. .venv/bin/activate && python scripts/validate_json.py contracts/policy.snapshot.schema.json /tmp/heimlern_snapshot.json
 	. .venv/bin/activate && python scripts/validate_json.py contracts/policy.feedback.schema.json /tmp/heimlern_feedback.json
+	python3 -m json.tool contracts/operator.routing_decision.v1.schema.json >/dev/null
+	python3 -m json.tool contracts/operator.routing_outcome.v1.schema.json >/dev/null
 	@echo "✓ alle Beispiel-Dokumente sind valide"
 
 # Lokaler Helper: Schnelltests & Linter – sicher mit Null-Trennung und Quoting

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -70,3 +70,10 @@ just schema:validate
 | `policy.weight_adjustment.v1` | Gewichtsanpassungsvorschläge | heimlern | hausKI |
 
 Für Details siehe: [heimgewebe/metarepo/contracts/](https://github.com/heimgewebe/metarepo/tree/main/contracts)
+
+## Operator routing
+
+- `operator.routing_decision.v1.schema.json`: records one bounded operator routing choice before the result is known.
+- `operator.routing_outcome.v1.schema.json`: records the retrospective result, reward and redacted friction metrics.
+
+These files are offline-learning inputs only. They do not authorize live routing changes.

--- a/contracts/operator.routing_decision.v1.schema.json
+++ b/contracts/operator.routing_decision.v1.schema.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://heimgewebe.local/heimlern/operator.routing_decision.v1.schema.json",
+  "title": "Operator Routing Decision v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "decision_id", "ts", "policy_id", "task_class", "candidate_routes", "chosen_route", "context", "does_not_establish"],
+  "properties": {
+    "version": {"const": "operator.routing_decision.v1"},
+    "decision_id": {"type": "string", "pattern": "^[A-Za-z0-9._:-]{1,160}$"},
+    "ts": {"type": "string", "format": "date-time"},
+    "policy_id": {"type": "string", "minLength": 1, "maxLength": 160},
+    "task_class": {"type": "string", "pattern": "^[a-z][a-z0-9._-]{0,80}$"},
+    "candidate_routes": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string", "pattern": "^[a-z][a-z0-9._:-]{0,119}$"}},
+    "chosen_route": {"type": "string", "pattern": "^[a-z][a-z0-9._:-]{0,119}$"},
+    "context": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["surface", "risk_class"],
+      "properties": {
+        "surface": {"type": "string", "pattern": "^[a-z][a-z0-9._:-]{0,119}$"},
+        "risk_class": {"enum": ["low", "medium", "high", "unknown"]},
+        "repository": {"type": "string", "minLength": 1, "maxLength": 240},
+        "current_ball": {"type": "string", "minLength": 1, "maxLength": 240},
+        "constraints": {"type": "array", "items": {"type": "string", "minLength": 1}, "uniqueItems": true},
+        "signals": {"type": "object", "additionalProperties": {"type": ["string", "number", "boolean", "null"]}}
+      }
+    },
+    "selection_reason": {"type": "string", "minLength": 1},
+    "evidence_refs": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["kind", "ref"],
+        "properties": {
+          "kind": {"type": "string", "pattern": "^[a-z][a-z0-9._:-]{0,80}$"},
+          "ref": {"type": "string", "minLength": 1},
+          "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"}
+        }
+      }
+    },
+    "does_not_establish": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string", "minLength": 1}}
+  }
+}

--- a/contracts/operator.routing_outcome.v1.schema.json
+++ b/contracts/operator.routing_outcome.v1.schema.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://heimgewebe.local/heimlern/operator.routing_outcome.v1.schema.json",
+  "title": "Operator Routing Outcome v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "decision_id", "ts", "task_class", "route_used", "outcome", "resolved", "reward", "metrics", "does_not_establish"],
+  "properties": {
+    "version": {"const": "operator.routing_outcome.v1"},
+    "decision_id": {"type": "string", "pattern": "^[A-Za-z0-9._:-]{1,160}$"},
+    "ts": {"type": "string", "format": "date-time"},
+    "task_class": {"type": "string", "pattern": "^[a-z][a-z0-9._-]{0,80}$"},
+    "route_used": {"type": "string", "pattern": "^[a-z][a-z0-9._:-]{0,119}$"},
+    "outcome": {"enum": ["success", "failure", "partial", "unknown"]},
+    "resolved": {"type": "boolean"},
+    "reward": {"type": "number", "minimum": -1.0, "maximum": 1.0},
+    "metrics": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["completion_state", "friction_count", "blocked_by_platform_filter", "manual_operator_needed"],
+      "properties": {
+        "completion_state": {"enum": ["completed", "blocked", "deferred", "failed", "unknown"]},
+        "friction_count": {"type": "integer", "minimum": 0},
+        "blocked_by_platform_filter": {"type": "boolean"},
+        "manual_operator_needed": {"type": "boolean"},
+        "ci_state": {"enum": ["pass", "fail", "pending", "not_applicable", "unknown"]},
+        "pr_state": {"enum": ["merged", "open", "closed", "not_applicable", "unknown"]},
+        "elapsed_seconds": {"type": "integer", "minimum": 0},
+        "rework_count": {"type": "integer", "minimum": 0}
+      }
+    },
+    "friction": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["kind", "surface", "resolved"],
+        "properties": {
+          "kind": {"enum": ["ci_contract", "connector_snapshot", "execution_context", "fail_closed_gate", "network", "operator_bug", "platform_filter", "unknown", "user_input"]},
+          "surface": {"type": "string", "minLength": 1, "maxLength": 160},
+          "operation": {"type": "string", "minLength": 1, "maxLength": 160},
+          "resolved": {"type": "boolean"},
+          "fallback": {"type": "string", "minLength": 1, "maxLength": 500}
+        }
+      }
+    },
+    "evidence_refs": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["kind", "ref"],
+        "properties": {
+          "kind": {"type": "string", "pattern": "^[a-z][a-z0-9._:-]{0,80}$"},
+          "ref": {"type": "string", "minLength": 1},
+          "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"}
+        }
+      }
+    },
+    "does_not_establish": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string", "minLength": 1}}
+  }
+}


### PR DESCRIPTION
## Summary
- add operator routing decision and outcome schemas
- document the offline learning boundary in contracts README
- add schema syntax checks to Justfile validation

## Validation
- just schema-validate

## Boundaries
- no live routing change
- no auto-apply behavior
- no adapter implementation yet
