### PR TITLE
fix: pin metarepo contract refs

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -7,7 +7,7 @@ on:
     - cron: "0 * * * *"
 
 env:
-  METRICS_SCHEMA_URL: https://raw.githubusercontent.com/heimgewebe/metarepo/main/contracts/metrics.snapshot.schema.json
+  METRICS_SCHEMA_URL: https://raw.githubusercontent.com/heimgewebe/metarepo/a1984186a98a1e4214769f87649c5affc9686a53/contracts/metrics.snapshot.schema.json
   HAUSKI_POST_URL: ${{ secrets.HAUSKI_METRICS_URL }}
 
 jobs:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Validate weight adjustment fixture against metarepo contract
         run: |
           mkdir -p .ci
-          curl -fsSL https://raw.githubusercontent.com/heimgewebe/metarepo/main/contracts/policy.weight_adjustment.v1.schema.json \
+          curl -fsSL https://raw.githubusercontent.com/heimgewebe/metarepo/a1984186a98a1e4214769f87649c5affc9686a53/contracts/policy.weight_adjustment.v1.schema.json \
             -o .ci/policy.weight_adjustment.v1.schema.json
           python scripts/validate_json.py \
             .ci/policy.weight_adjustment.v1.schema.json \


### PR DESCRIPTION
Pin heimlern CI contract fetches to metarepo commit a1984186a98a1e4214769f87649c5affc9686a53. Gates: no metarepo main contract URLs remain; pinned weight-adjustment fixture validation passes; pinned metrics AJV validation passes.