### PR TITLE
feat: map oplearn outcomes to feedback records

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -54,8 +54,11 @@ jobs:
       - name: Smoke OPLEARN adapter
         run: |
           python scripts/ola_adapter.py --self-test
-          python scripts/ola_adapter.py tests/fixtures/ola/input.ok.json > /tmp/ola-routing-outcome.json
-          python scripts/validate_json.py contracts/operator.routing_outcome.v1.schema.json /tmp/ola-routing-outcome.json
+          for input in tests/fixtures/ola/*.ok.json; do
+            python scripts/ola_adapter.py "$input" > /tmp/ola-routing-outcome.json
+            python scripts/validate_json.py contracts/operator.routing_outcome.v1.schema.json /tmp/ola-routing-outcome.json
+            python scripts/ola_adapter.py --emit decision-outcome "$input" > /tmp/ola-decision-outcome.json
+          done
 
       - name: Validate weight adjustment fixture against metarepo contract
         run: |

--- a/scripts/ola_adapter.py
+++ b/scripts/ola_adapter.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any
 
 OUTCOME_VERSION = "operator.routing_outcome.v1"
+DEFAULT_POLICY_ID = "grabowski-routing-v0"
 VALID_COMPLETION_STATES = {"completed", "blocked", "deferred", "failed", "unknown"}
 VALID_CI_STATES = {"pass", "fail", "pending", "not_applicable", "unknown"}
 VALID_PR_STATES = {"merged", "open", "closed", "not_applicable", "unknown"}
@@ -158,6 +159,30 @@ def adapt(input_record: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def to_decision_outcome(routing_outcome: dict[str, Any], policy_id: str = DEFAULT_POLICY_ID) -> dict[str, Any]:
+    outcome = str(routing_outcome.get("outcome") or "unknown")
+    success = outcome == "success"
+    if outcome == "partial":
+        success = bool_from(routing_outcome.get("resolved"))
+    route_used = str(routing_outcome.get("route_used") or "unknown_route")
+    return {
+        "decision_id": str(routing_outcome.get("decision_id") or "unknown-decision"),
+        "ts": str(routing_outcome.get("ts") or iso_now()),
+        "policy_id": policy_id,
+        "action": f"route.{route_used}",
+        "outcome": outcome,
+        "success": success,
+        "reward": routing_outcome.get("reward"),
+        "context": {"task_class": routing_outcome.get("task_class"), "route_used": route_used},
+        "metadata": {
+            "source_version": routing_outcome.get("version"),
+            "metrics": routing_outcome.get("metrics", {}),
+            "friction": routing_outcome.get("friction", []),
+            "does_not_establish": ["routing_policy_readiness", "automatic_rule_change_permission"],
+        },
+    }
+
+
 def run_self_test() -> None:
     sample = {
         "decision_id": "gr-example-001",
@@ -186,6 +211,8 @@ def run_self_test() -> None:
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("input", nargs="?", help="Path to a redacted JSON input record")
+    parser.add_argument("--emit", choices=["routing-outcome", "decision-outcome"], default="routing-outcome")
+    parser.add_argument("--policy-id", default=DEFAULT_POLICY_ID)
     parser.add_argument("--self-test", action="store_true")
     args = parser.parse_args()
     if args.self_test:
@@ -195,7 +222,9 @@ def main() -> int:
     if not args.input:
         parser.error("input path required unless --self-test is used")
     input_record = json.loads(Path(args.input).read_text(encoding="utf-8"))
-    print(json.dumps(adapt(input_record), indent=2, ensure_ascii=False))
+    routing_outcome = adapt(input_record)
+    payload = to_decision_outcome(routing_outcome, args.policy_id) if args.emit == "decision-outcome" else routing_outcome
+    print(json.dumps(payload, indent=2, ensure_ascii=False))
     return 0
 
 

--- a/tests/fixtures/ola/failclosed.ok.json
+++ b/tests/fixtures/ola/failclosed.ok.json
@@ -1,0 +1,20 @@
+{
+  "decision_id": "gr-failclosed-001",
+  "ts": "2026-07-05T12:03:00Z",
+  "task_class": "safety_slice",
+  "route_used": "typed_tool",
+  "completion_state": "deferred",
+  "ci_state": "not_applicable",
+  "pr_state": "not_applicable",
+  "elapsed_seconds": 30,
+  "rework_count": 0,
+  "friction": [
+    {
+      "kind": "fail_closed_gate",
+      "surface": "runtime_gate",
+      "operation": "preflight",
+      "resolved": true,
+      "fallback": "stopped without mutation"
+    }
+  ]
+}

--- a/tests/fixtures/ola/failed.ok.json
+++ b/tests/fixtures/ola/failed.ok.json
@@ -1,0 +1,19 @@
+{
+  "decision_id": "gr-failed-001",
+  "ts": "2026-07-05T12:02:00Z",
+  "task_class": "runtime_slice",
+  "route_used": "direct_patch",
+  "completion_state": "failed",
+  "ci_state": "fail",
+  "pr_state": "closed",
+  "elapsed_seconds": 180,
+  "rework_count": 2,
+  "friction": [
+    {
+      "kind": "operator_bug",
+      "surface": "local_tool",
+      "operation": "patch_apply",
+      "resolved": false
+    }
+  ]
+}

--- a/tests/fixtures/ola/success.ok.json
+++ b/tests/fixtures/ola/success.ok.json
@@ -1,0 +1,12 @@
+{
+  "decision_id": "gr-success-001",
+  "ts": "2026-07-05T12:00:00Z",
+  "task_class": "contract_slice",
+  "route_used": "typed_tool",
+  "completion_state": "completed",
+  "ci_state": "pass",
+  "pr_state": "merged",
+  "elapsed_seconds": 60,
+  "rework_count": 0,
+  "friction": []
+}


### PR DESCRIPTION
Add DecisionOutcome emit mode and OLA corpus cases for success, blocked, failed, and fail-closed. Validation: adapter self-test, routing outcome schema validation, DecisionOutcome JSON smoke, py_compile, just schema-validate.