### PR TITLE
fix: harden policy feedback contract

### DIFF
--- a/.github/workflows/validate-feedback-schema.yml
+++ b/.github/workflows/validate-feedback-schema.yml
@@ -1,0 +1,21 @@
+name: validate-feedback-schema
+permissions:
+  contents: read
+on:
+  pull_request:
+    paths:
+      - "contracts/policy.feedback.schema.json"
+      - "data/samples/policy.feedback.sample.json"
+      - "tests/fixtures/feedback/policy.feedback.bad.json"
+      - "tests/validate_feedback_schema.py"
+      - ".github/workflows/validate-feedback-schema.yml"
+  workflow_dispatch:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - run: python3 -m pip install --user -r requirements-tools.txt
+      - run: python3 tests/validate_feedback_schema.py

--- a/contracts/policy.feedback.schema.json
+++ b/contracts/policy.feedback.schema.json
@@ -8,16 +8,22 @@
   "required": [
     "feedback_id",
     "decision_id",
-    "reward"
+    "reward",
+    "source",
+    "ts"
   ],
   "properties": {
     "feedback_id": {
       "type": "string",
-      "minLength": 1
+      "minLength": 1,
+      "maxLength": 128,
+      "pattern": "^fb-[A-Za-z0-9._:-]+$"
     },
     "decision_id": {
       "type": "string",
-      "minLength": 1
+      "minLength": 1,
+      "maxLength": 128,
+      "pattern": "^dec-[A-Za-z0-9._:-]+$"
     },
     "reward": {
       "type": "number",
@@ -26,18 +32,31 @@
     },
     "comment": {
       "type": "string",
-      "minLength": 1
+      "minLength": 1,
+      "maxLength": 2000
     },
     "source": {
       "type": "string",
-      "minLength": 1
+      "minLength": 2,
+      "maxLength": 64,
+      "pattern": "^[a-z][a-z0-9._-]*$"
     },
     "ts": {
       "type": "string",
       "format": "date-time"
     },
     "metadata": {
-      "type": "object"
+      "type": "object",
+      "maxProperties": 20,
+      "additionalProperties": {
+        "type": [
+          "string",
+          "number",
+          "integer",
+          "boolean",
+          "null"
+        ]
+      }
     }
   }
 }

--- a/data/samples/policy.feedback.sample.json
+++ b/data/samples/policy.feedback.sample.json
@@ -2,5 +2,10 @@
   "feedback_id": "fb-123",
   "decision_id": "dec-456",
   "reward": 1.0,
-  "comment": "Good job"
+  "source": "operator",
+  "ts": "2026-07-07T11:34:00Z",
+  "comment": "Good job",
+  "metadata": {
+    "task": "HEIMLERN-OPTIMIZATION-V1-T001"
+  }
 }

--- a/tests/fixtures/feedback/policy.feedback.bad.json
+++ b/tests/fixtures/feedback/policy.feedback.bad.json
@@ -1,0 +1,5 @@
+{
+  "feedback_id": "fb-bad-001",
+  "reward": 2.0,
+  "comment": "missing decision_id and out-of-range reward"
+}

--- a/tests/validate_feedback_schema.py
+++ b/tests/validate_feedback_schema.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+from jsonschema.exceptions import ValidationError
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+from validate_json import ContractError, validate_single  # noqa: E402
+
+SCHEMA = ROOT / "contracts" / "policy.feedback.schema.json"
+POSITIVE = ROOT / "data" / "samples" / "policy.feedback.sample.json"
+NEGATIVE = ROOT / "tests" / "fixtures" / "feedback" / "policy.feedback.bad.json"
+
+
+def main() -> int:
+    validate_single(SCHEMA, POSITIVE)
+
+    try:
+        validate_single(SCHEMA, NEGATIVE)
+    except (ContractError, ValidationError):
+        print("feedback negative fixture rejected")
+        return 0
+
+    print("feedback negative fixture was accepted", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Follow-up to PR 184.

This completes HEIMLERN-OPTIMIZATION-V1-T001 by adding the actual feedback contract changes:

- require source and timestamp on feedback documents
- constrain feedback_id and decision_id formats and lengths
- constrain source format and length
- cap comment length
- constrain metadata to a small scalar map
- update the positive sample to match the hardened contract

The existing validation workflow should now cover the hardened schema and sample.