### PR TITLE
feat: add offline learning path cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,6 +312,7 @@ name = "heimlern-cli"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "assert_cmd",
  "clap",
  "heimlern-core",
  "serde",

--- a/contracts/learning_path.schema.json
+++ b/contracts/learning_path.schema.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.heimgewebe.org/contracts/heimlern.offline_learning_path.v1.schema.json",
+  "title": "Offline Learning Path",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "artifact", "mode", "generated_by", "writes_production", "steps"],
+  "properties": {
+    "schema_version": {"type": "integer", "const": 1},
+    "artifact": {"type": "string", "const": "heimlern.offline_learning_path.v1"},
+    "mode": {"type": "string", "const": "offline"},
+    "generated_by": {"type": "string", "const": "heimlern-cli"},
+    "writes_production": {"type": "boolean", "const": false},
+    "steps": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "title", "command", "read_only"],
+        "properties": {
+          "id": {"type": "string", "minLength": 1},
+          "title": {"type": "string", "minLength": 1},
+          "command": {"type": "string", "minLength": 1},
+          "read_only": {"type": "boolean", "const": true}
+        }
+      }
+    }
+  }
+}

--- a/crates/heimlern-cli/Cargo.toml
+++ b/crates/heimlern-cli/Cargo.toml
@@ -21,3 +21,5 @@ url = "2.5.8"
 
 [dev-dependencies]
 tempfile = "3"
+
+assert_cmd = "2.1"

--- a/crates/heimlern-cli/src/main.rs
+++ b/crates/heimlern-cli/src/main.rs
@@ -29,6 +29,17 @@ enum Commands {
         #[command(subcommand)]
         source: IngestSource,
     },
+    /// Emit read-only learning path artifacts
+    LearningPath {
+        #[command(subcommand)]
+        path: LearningPathCommand,
+    },
+}
+
+#[derive(Subcommand)]
+enum LearningPathCommand {
+    /// Emit the offline learning path JSON artifact to stdout
+    Offline,
 }
 
 #[derive(Subcommand)]
@@ -77,6 +88,56 @@ enum IngestSource {
         #[arg(long, default_value = "data/heimlern.stats.json")]
         stats_file: PathBuf,
     },
+}
+
+#[derive(Serialize, Debug)]
+struct OfflineLearningPathArtifact {
+    schema_version: u8,
+    artifact: String,
+    mode: String,
+    generated_by: String,
+    writes_production: bool,
+    steps: Vec<OfflineLearningPathStep>,
+}
+
+#[derive(Serialize, Debug)]
+struct OfflineLearningPathStep {
+    id: String,
+    title: String,
+    command: String,
+    read_only: bool,
+}
+
+fn offline_learning_path_artifact() -> OfflineLearningPathArtifact {
+    OfflineLearningPathArtifact {
+        schema_version: 1,
+        artifact: "heimlern.offline_learning_path.v1".to_string(),
+        mode: "offline".to_string(),
+        generated_by: "heimlern-cli".to_string(),
+        writes_production: false,
+        steps: vec![
+            OfflineLearningPathStep {
+                id: "validate-contracts".to_string(),
+                title: "Validate checked-in contracts and samples".to_string(),
+                command:
+                    "python3 scripts/validate_json.py --schemas contracts --samples data/samples"
+                        .to_string(),
+                read_only: true,
+            },
+            OfflineLearningPathStep {
+                id: "run-rust-tests".to_string(),
+                title: "Run the Rust workspace test suite".to_string(),
+                command: "cargo test".to_string(),
+                read_only: true,
+            },
+            OfflineLearningPathStep {
+                id: "inspect-feedback-proposals".to_string(),
+                title: "Inspect generated feedback proposals without applying them".to_string(),
+                command: "cargo run -p heimlern-feedback --example feedback_analysis".to_string(),
+                read_only: true,
+            },
+        ],
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Copy)]
@@ -478,6 +539,12 @@ fn main() -> Result<()> {
     let cli = Cli::parse();
 
     match cli.command {
+        Commands::LearningPath { path } => match path {
+            LearningPathCommand::Offline => {
+                let artifact = offline_learning_path_artifact();
+                println!("{}", serde_json::to_string_pretty(&artifact)?);
+            }
+        },
         Commands::Ingest { source } => match source {
             IngestSource::Chronik {
                 cursor,

--- a/crates/heimlern-cli/tests/offline_learning_path.rs
+++ b/crates/heimlern-cli/tests/offline_learning_path.rs
@@ -1,0 +1,120 @@
+use assert_cmd::Command;
+use serde_json::Value;
+use std::collections::BTreeSet;
+use std::fs;
+
+#[allow(deprecated)]
+#[test]
+fn offline_learning_path_emits_schema_valid_read_only_artifact() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let output = Command::cargo_bin("heimlern")
+        .expect("binary")
+        .current_dir(temp.path())
+        .args(["learning-path", "offline"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let artifact: Value = serde_json::from_slice(&output).expect("json artifact");
+    let schema = learning_path_schema();
+    validate_artifact_against_checked_in_schema(&schema, &artifact);
+
+    assert_eq!(artifact["artifact"], "heimlern.offline_learning_path.v1");
+    assert_eq!(artifact["mode"], "offline");
+    assert_eq!(artifact["writes_production"], false);
+    assert!(artifact["steps"].as_array().expect("steps").len() >= 3);
+    assert!(artifact["steps"]
+        .as_array()
+        .expect("steps")
+        .iter()
+        .all(|step| step["read_only"] == true));
+
+    let entries = fs::read_dir(temp.path()).expect("read tempdir");
+    assert_eq!(entries.count(), 0, "CLI must write only to stdout");
+}
+
+fn learning_path_schema() -> Value {
+    let repo_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|p| p.parent())
+        .expect("repo root");
+    let schema_path = repo_root.join("contracts/learning_path.schema.json");
+    serde_json::from_str(&fs::read_to_string(schema_path).expect("schema file"))
+        .expect("schema json")
+}
+
+fn validate_artifact_against_checked_in_schema(schema: &Value, artifact: &Value) {
+    assert_eq!(schema["type"], "object");
+    assert_eq!(schema["additionalProperties"], false);
+
+    let object = artifact.as_object().expect("artifact object");
+    let required = schema["required"].as_array().expect("required array");
+    for field in required {
+        let field = field.as_str().expect("required field name");
+        assert!(object.contains_key(field), "missing required field {field}");
+    }
+
+    let allowed: BTreeSet<_> = schema["properties"]
+        .as_object()
+        .expect("schema properties")
+        .keys()
+        .cloned()
+        .collect();
+    for key in object.keys() {
+        assert!(allowed.contains(key), "unexpected artifact field {key}");
+    }
+
+    assert_const(schema, artifact, "schema_version");
+    assert_const(schema, artifact, "artifact");
+    assert_const(schema, artifact, "mode");
+    assert_const(schema, artifact, "generated_by");
+    assert_const(schema, artifact, "writes_production");
+
+    let steps = artifact["steps"].as_array().expect("steps array");
+    let min_items = schema["properties"]["steps"]["minItems"]
+        .as_u64()
+        .expect("steps minItems") as usize;
+    assert!(steps.len() >= min_items);
+
+    let step_schema = &schema["properties"]["steps"]["items"];
+    assert_eq!(step_schema["type"], "object");
+    assert_eq!(step_schema["additionalProperties"], false);
+    let step_allowed: BTreeSet<_> = step_schema["properties"]
+        .as_object()
+        .expect("step properties")
+        .keys()
+        .cloned()
+        .collect();
+    let step_required = step_schema["required"].as_array().expect("step required");
+    for step in steps {
+        let step_object = step.as_object().expect("step object");
+        for field in step_required {
+            let field = field.as_str().expect("step required field");
+            assert!(
+                step_object.contains_key(field),
+                "missing step field {field}"
+            );
+        }
+        for key in step_object.keys() {
+            assert!(step_allowed.contains(key), "unexpected step field {key}");
+        }
+        assert_eq!(
+            step["read_only"],
+            step_schema["properties"]["read_only"]["const"]
+        );
+        for field in ["id", "title", "command"] {
+            assert!(step[field].as_str().is_some_and(|value| !value.is_empty()));
+        }
+    }
+}
+
+fn assert_const(schema: &Value, artifact: &Value, field: &str) {
+    let expected = &schema["properties"][field]["const"];
+    assert!(
+        !expected.is_null(),
+        "schema field {field} must define const"
+    );
+    assert_eq!(&artifact[field], expected, "const mismatch for {field}");
+}


### PR DESCRIPTION
Implements HEIMLERN-OPTIMIZATION-V1-T003.

Summary:
- Adds `heimlern learning-path offline` as a read-only CLI artifact.
- Adds `contracts/learning_path.schema.json`.
- Adds a Rust integration test that validates emitted JSON against the checked-in schema shape and asserts stdout-only behavior.

Local verification:
- `cargo fmt --all --check`
- `cargo test -p heimlern-cli --test offline_learning_path --locked`
- `cargo test --all --locked --workspace`
- `cargo clippy --all-targets -- -D warnings`
- `cargo run -p heimlern-cli -- learning-path offline > /tmp/heimlern-learning-path.json`
- `python3 scripts/validate_json.py contracts/learning_path.schema.json /tmp/heimlern-learning-path.json`

Does not establish runtime policy readiness, automatic rule changes, or production application of learning proposals.
