### PR TITLE
fix: remove duplicate ai-context guard permissions

### DIFF
--- a/.github/workflows/ai-context-guard.yml
+++ b/.github/workflows/ai-context-guard.yml
@@ -1,8 +1,5 @@
 name: ai-context guard
 
-permissions:
-  contents: read
-
 on:
   pull_request:
   push:


### PR DESCRIPTION
Fixes the failed Heimlern main run after PR #187.

Cause:
- `.github/workflows/ai-context-guard.yml` had duplicate top-level `permissions:` keys.
- The failed main run had no jobs/logs, which is consistent with workflow-file parsing/validation failure before job execution.

Change:
- Remove the duplicate first `permissions:` block and keep the later canonical top-level `permissions: contents: read` block.

Local verification:
- YAML parsed with PyYAML and contains `jobs.repo-root`, `jobs.templates`, and `permissions.contents=read`.
- `python3 scripts/ai_context/validate_ai_context.py --file .ai-context.yml`
- `cargo test --all --locked --workspace`

Boundary:
- Workflow-only fix.
- No learning-policy or runtime behavior change.
