### PR TITLE
bench: decide release opt profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,6 @@ resolver = "2"
 members = ["crates/heimlern-core","crates/heimlern-bandits","crates/heimlern-feedback","crates/heimlern-cli"]
 
 [profile.release]
-opt-level = "z"
+opt-level = "s"
 lto = true
 codegen-units = 1

--- a/Justfile
+++ b/Justfile
@@ -36,3 +36,7 @@ lint:
     printf '%s\0' "${files[@]}" | xargs -0 bash -n; \
     shfmt -d -i 2 -ci -sr -- "${files[@]}"; \
     shellcheck -S style -- "${files[@]}"
+
+# ---- Release-Profil Benchmark ----
+release-profile-bench:
+	python3 scripts/benchmark_release_profiles.py --out docs/benchmarks/release-profile-comparison.latest.json

--- a/crates/heimlern-bandits/examples/bench_feedback.rs
+++ b/crates/heimlern-bandits/examples/bench_feedback.rs
@@ -1,73 +1,229 @@
 use heimlern_bandits::RemindBandit;
 use heimlern_core::{Context, Policy};
-use std::fmt::Write;
+use serde::Serialize;
+use std::fmt::Write as _;
+use std::hint::black_box;
 use std::time::Instant;
 
 /// Must be kept in sync with `MAX_ARMS` in `crates/heimlern-bandits/src/lib.rs`.
 const CAP: usize = 1000;
 
-fn main() {
-    let mut bandit = RemindBandit::default();
+#[derive(Debug, Clone, Copy)]
+struct BenchConfig {
+    iterations: u64,
+    replay_iterations: u64,
+    fill_cap: usize,
+    warmup: u64,
+    samples: u32,
+    json: bool,
+}
+
+impl Default for BenchConfig {
+    fn default() -> Self {
+        Self {
+            iterations: 1_000_000,
+            replay_iterations: 10_000,
+            fill_cap: CAP,
+            warmup: 1_000,
+            samples: 1,
+            json: false,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct BenchReport {
+    benchmark: &'static str,
+    cap: usize,
+    iterations: u64,
+    replay_iterations: u64,
+    fill_cap: usize,
+    warmup: u64,
+    samples: Vec<BenchSample>,
+}
+
+#[derive(Debug, Serialize)]
+struct BenchSample {
+    sample: u32,
+    existing_slot_total_ns: u128,
+    existing_slot_ns_per_call: f64,
+    filling_slots_total_ns: u128,
+    filling_slots_ns_per_call: f64,
+    snapshot_replay_total_ns: u128,
+    snapshot_replay_ns_per_call: f64,
+}
+
+fn parse_u64_arg(args: &[String], index: &mut usize, name: &str) -> Result<u64, String> {
+    *index += 1;
+    let value = args
+        .get(*index)
+        .ok_or_else(|| format!("{name} requires a numeric value"))?;
+    value
+        .parse::<u64>()
+        .map_err(|err| format!("invalid value for {name}: {err}"))
+}
+
+fn parse_usize_arg(args: &[String], index: &mut usize, name: &str) -> Result<usize, String> {
+    *index += 1;
+    let value = args
+        .get(*index)
+        .ok_or_else(|| format!("{name} requires a numeric value"))?;
+    value
+        .parse::<usize>()
+        .map_err(|err| format!("invalid value for {name}: {err}"))
+}
+
+fn parse_u32_arg(args: &[String], index: &mut usize, name: &str) -> Result<u32, String> {
+    *index += 1;
+    let value = args
+        .get(*index)
+        .ok_or_else(|| format!("{name} requires a numeric value"))?;
+    value
+        .parse::<u32>()
+        .map_err(|err| format!("invalid value for {name}: {err}"))
+}
+
+fn parse_config() -> Result<BenchConfig, String> {
+    let args: Vec<String> = std::env::args().collect();
+    let mut config = BenchConfig::default();
+    let mut index = 1;
+    while index < args.len() {
+        match args[index].as_str() {
+            "--json" => config.json = true,
+            "--iterations" => config.iterations = parse_u64_arg(&args, &mut index, "--iterations")?,
+            "--replay-iterations" => {
+                config.replay_iterations = parse_u64_arg(&args, &mut index, "--replay-iterations")?;
+            }
+            "--fill-cap" => config.fill_cap = parse_usize_arg(&args, &mut index, "--fill-cap")?,
+            "--warmup" => config.warmup = parse_u64_arg(&args, &mut index, "--warmup")?,
+            "--samples" => config.samples = parse_u32_arg(&args, &mut index, "--samples")?,
+            "--help" | "-h" => {
+                println!(
+                    "Usage: bench_feedback [--json] [--iterations N] [--replay-iterations N] [--fill-cap N] [--warmup N] [--samples N]"
+                );
+                std::process::exit(0);
+            }
+            other => return Err(format!("unknown argument: {other}")),
+        }
+        index += 1;
+    }
+
+    if config.iterations == 0 {
+        return Err("--iterations must be greater than 0".to_string());
+    }
+    if config.replay_iterations == 0 {
+        return Err("--replay-iterations must be greater than 0".to_string());
+    }
+    if config.fill_cap == 0 || config.fill_cap > CAP {
+        return Err(format!("--fill-cap must be between 1 and {CAP}"));
+    }
+    if config.samples == 0 {
+        return Err("--samples must be greater than 0".to_string());
+    }
+    Ok(config)
+}
+
+fn ns_per_call(total_ns: u128, calls: u64) -> f64 {
+    total_ns as f64 / calls as f64
+}
+
+fn run_one_sample(config: BenchConfig, sample: u32) -> BenchSample {
     let ctx = Context {
         kind: "bench".into(),
         features: serde_json::json!({}),
     };
-
-    let iterations = 1_000_000;
-    let action = "remind.morning";
+    let action = "remind.bench_existing";
     let reward = 1.0;
 
-    // Warmup
-    for _ in 0..1000 {
-        bandit.feedback(&ctx, action, reward);
-    }
-
-    let start = Instant::now();
-    for _ in 0..iterations {
-        bandit.feedback(&ctx, action, reward);
-    }
-    let duration = start.elapsed();
-
-    println!("Feedback for EXISTING slot took: {:?}", duration);
-    println!("Average per call: {:?}", duration / iterations as u32);
-
-    // Measure filling up to capacity
     let mut bandit = RemindBandit::default();
-    let start = Instant::now();
-    for i in 0..CAP {
-        let action = format!("remind.slot_{}", i);
-        bandit.feedback(&ctx, &action, reward);
+    for _ in 0..config.warmup {
+        bandit.feedback(black_box(&ctx), black_box(action), black_box(reward));
     }
-    let duration = start.elapsed();
-    println!(
-        "Feedback for FILLING slots (0..{}) took: {:?}",
-        CAP, duration
-    );
-    println!(
-        "Average per call: {:?}",
-        duration / u32::try_from(CAP).unwrap()
-    );
 
-    // Measure rejection overhead (slots full)
-    // We reuse the bandit which is now full (len == CAP)
-    let reject_iterations = 1_000_000;
-    // Reuse buffer to avoid allocation noise in the benchmark loop
+    let start = Instant::now();
+    for _ in 0..config.iterations {
+        bandit.feedback(black_box(&ctx), black_box(action), black_box(reward));
+    }
+    let existing_slot_total_ns = start.elapsed().as_nanos();
+
+    let mut bandit = RemindBandit::default();
     let mut action_buf = String::with_capacity(32);
     let start = Instant::now();
-    for i in 0..reject_iterations {
-        // These are new slot names, so they trigger the "new slot" path,
-        // but get rejected because len >= MAX_ARMS.
+    for i in 0..config.fill_cap {
         action_buf.clear();
-        write!(&mut action_buf, "remind.reject_{}", i).unwrap();
-        bandit.feedback(&ctx, &action_buf, reward);
+        let _ = write!(&mut action_buf, "remind.slot_{i}");
+        bandit.feedback(black_box(&ctx), black_box(&action_buf), black_box(reward));
     }
-    let duration = start.elapsed();
-    println!(
-        "Feedback for REJECTING slots (over capacity) took: {:?}",
-        duration
-    );
-    println!(
-        "Average per call: {:?}",
-        duration / reject_iterations as u32
-    );
+    let filling_slots_total_ns = start.elapsed().as_nanos();
+
+    let snapshot = black_box(bandit.snapshot());
+    let start = Instant::now();
+    for _ in 0..config.replay_iterations {
+        let mut replayed = RemindBandit::default();
+        replayed.load(black_box(snapshot.clone()));
+        black_box(replayed.snapshot());
+    }
+    let snapshot_replay_total_ns = start.elapsed().as_nanos();
+
+    BenchSample {
+        sample,
+        existing_slot_total_ns,
+        existing_slot_ns_per_call: ns_per_call(existing_slot_total_ns, config.iterations),
+        filling_slots_total_ns,
+        filling_slots_ns_per_call: ns_per_call(filling_slots_total_ns, config.fill_cap as u64),
+        snapshot_replay_total_ns,
+        snapshot_replay_ns_per_call: ns_per_call(
+            snapshot_replay_total_ns,
+            config.replay_iterations,
+        ),
+    }
+}
+
+fn run_benchmark(config: BenchConfig) -> BenchReport {
+    let samples = (1..=config.samples)
+        .map(|sample| run_one_sample(config, sample))
+        .collect();
+    BenchReport {
+        benchmark: "heimlern-bandits.feedback_paths.v1",
+        cap: CAP,
+        iterations: config.iterations,
+        replay_iterations: config.replay_iterations,
+        fill_cap: config.fill_cap,
+        warmup: config.warmup,
+        samples,
+    }
+}
+
+fn print_text(report: &BenchReport) {
+    println!("Benchmark: {}", report.benchmark);
+    println!("CAP: {}", report.cap);
+    println!("Iterations: {}", report.iterations);
+    println!("Replay iterations: {}", report.replay_iterations);
+    println!("Fill cap: {}", report.fill_cap);
+    for sample in &report.samples {
+        println!("Sample {}", sample.sample);
+        println!(
+            "  existing slot: {} ns total, {:.3} ns/call",
+            sample.existing_slot_total_ns, sample.existing_slot_ns_per_call
+        );
+        println!(
+            "  filling slots: {} ns total, {:.3} ns/call",
+            sample.filling_slots_total_ns, sample.filling_slots_ns_per_call
+        );
+        println!(
+            "  snapshot replay: {} ns total, {:.3} ns/call",
+            sample.snapshot_replay_total_ns, sample.snapshot_replay_ns_per_call
+        );
+    }
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let config = parse_config().map_err(|err| format!("configuration error: {err}"))?;
+    let report = run_benchmark(config);
+    if config.json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+    } else {
+        print_text(&report);
+    }
+    Ok(())
 }

--- a/docs/adr/0004-release-opt-level-s.md
+++ b/docs/adr/0004-release-opt-level-s.md
@@ -1,0 +1,78 @@
+# ADR-0004: Release-Profil `opt-level = "s"`
+
+Status: accepted
+Date: 2026-07-08
+
+## Context
+
+The workspace previously used `opt-level = "z"` for release builds. That setting
+optimizes for size, but the decision had not been backed by a reproducible local
+measurement for Heimlern's current feedback-oriented workload.
+
+`HEIMLERN-OPTIMIZATION-V1-T004` requires a reproducible comparison of `z`, `s`
+and `3`, including size and runtime, plus a short release-profile decision.
+
+## Benchmark
+
+The benchmark is intentionally small and local:
+
+```text
+python3 scripts/benchmark_release_profiles.py \
+  --profiles z,s,3 \
+  --iterations 200000 \
+  --replay-iterations 5000 \
+  --fill-cap 1000 \
+  --warmup 1000 \
+  --samples 3 \
+  --out docs/benchmarks/release-profile-comparison-2026-07-08.json
+```
+
+It builds the `heimlern-bandits` `bench_feedback` example once per profile with
+`CARGO_PROFILE_RELEASE_OPT_LEVEL` and isolated target directories. It records:
+
+- release example binary size;
+- median existing-slot feedback time;
+- median new-slot fill time;
+- median snapshot replay time.
+
+Raw evidence:
+
+- `docs/benchmarks/release-profile-comparison-2026-07-08.json`
+- `scripts/benchmark_release_profiles.py`
+- `crates/heimlern-bandits/examples/bench_feedback.rs`
+
+## Results
+
+| opt-level | binary size bytes | existing-slot ns/call median | fill-slots ns/call median | snapshot-replay ns/call median |
+| --- | ---: | ---: | ---: | ---: |
+| `z` | 538056 | 30.489175 | 1339.547000 | 284688.445000 |
+| `s` | 535680 | 21.674825 | 1401.828000 | 237552.617000 |
+| `3` | 579272 | 19.734960 | 1362.578000 | 218003.675000 |
+
+## Decision
+
+Use `opt-level = "s"` for the workspace release profile.
+
+Rationale:
+
+- `s` produced the smallest measured binary in this run.
+- `s` was materially faster than `z` on the existing-slot and snapshot-replay paths.
+- `3` was fastest overall, but increased binary size enough that it does not fit the current size-conscious release premise.
+- The previous `z` setting is not retained because it was neither the smallest nor the fastest measured profile in this benchmark.
+
+## Consequences
+
+- The workspace release profile changes from `z` to `s`.
+- The comparison remains reproducible through the checked-in benchmark script and raw JSON report.
+- Future production-like workloads may justify a different profile, but that requires a new measured decision.
+
+## Limits / Non-claims
+
+This decision does not establish:
+
+- production runtime performance;
+- all-workload performance;
+- cross-machine reproducibility;
+- learning quality;
+- policy quality;
+- that `s` is optimal for future workloads.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -5,3 +5,4 @@
 - [ADR-0001: Policy/Decision als Rust-Lib, Explainability (`why`)](0001-policy-explainability.md)
 - [ADR-0002: Policy-Snapshot-Persistenz (SQLite via hausKI)](0002-policy-snapshot-persistenz.md)
 - [ADR-0003: Decision Feedback Analysis & Weight-Tuning](0003-decision-feedback-analysis.md)
+- [ADR-0004: Release-Profil `opt-level = "s"`](0004-release-opt-level-s.md)

--- a/docs/benchmarks/release-profile-comparison-2026-07-08.json
+++ b/docs/benchmarks/release-profile-comparison-2026-07-08.json
@@ -1,0 +1,190 @@
+{
+  "command": {
+    "fill_cap": 1000,
+    "iterations": 200000,
+    "profiles": [
+      "z",
+      "s",
+      "3"
+    ],
+    "replay_iterations": 5000,
+    "samples": 3,
+    "warmup": 1000
+  },
+  "decision_inputs": {
+    "fastest_existing_slot_profile": "3",
+    "smallest_binary_profile": "s"
+  },
+  "does_not_establish": [
+    "production_runtime_performance",
+    "all_workload_performance",
+    "cross_machine_reproducibility",
+    "policy_quality",
+    "learning_quality"
+  ],
+  "generated_at": "2026-07-08T16:31:48Z",
+  "git_dirty": true,
+  "git_head": "cbcf03fa09ff40846bdf0f76286ade72268dea5c",
+  "host": {
+    "platform": "Linux-7.0.11-76070011-generic-x86_64-with-glibc2.35",
+    "processor": "x86_64",
+    "python": "3.10.12"
+  },
+  "kind": "heimlern.release_profile_benchmark.v1",
+  "results": [
+    {
+      "benchmark": {
+        "benchmark": "heimlern-bandits.feedback_paths.v1",
+        "cap": 1000,
+        "fill_cap": 1000,
+        "iterations": 200000,
+        "replay_iterations": 5000,
+        "samples": [
+          {
+            "existing_slot_ns_per_call": 35.716955,
+            "existing_slot_total_ns": 7143391,
+            "filling_slots_ns_per_call": 1558.249,
+            "filling_slots_total_ns": 1558249,
+            "sample": 1,
+            "snapshot_replay_ns_per_call": 355398.278,
+            "snapshot_replay_total_ns": 1776991390
+          },
+          {
+            "existing_slot_ns_per_call": 30.39397,
+            "existing_slot_total_ns": 6078794,
+            "filling_slots_ns_per_call": 1296.308,
+            "filling_slots_total_ns": 1296308,
+            "sample": 2,
+            "snapshot_replay_ns_per_call": 284688.445,
+            "snapshot_replay_total_ns": 1423442225
+          },
+          {
+            "existing_slot_ns_per_call": 30.489175,
+            "existing_slot_total_ns": 6097835,
+            "filling_slots_ns_per_call": 1339.547,
+            "filling_slots_total_ns": 1339547,
+            "sample": 3,
+            "snapshot_replay_ns_per_call": 284473.3458,
+            "snapshot_replay_total_ns": 1422366729
+          }
+        ],
+        "warmup": 1000
+      },
+      "binary": "target/release-profile-bench/z/release/examples/bench_feedback",
+      "binary_size_bytes": 538056,
+      "build_seconds": 2.3108553989441134,
+      "build_stderr_tail": "   Compiling heimlern-bandits v0.1.0 (/home/alex/repos/.heimlern-worktrees/opt-profile-benchmark-v1/crates/heimlern-bandits)\n    Finished `release` profile [optimized] target(s) in 2.27s",
+      "cargo_profile_release_opt_level": "z",
+      "profile": "z",
+      "summary": {
+        "existing_slot_ns_per_call_median": 30.489175,
+        "filling_slots_ns_per_call_median": 1339.547,
+        "snapshot_replay_ns_per_call_median": 284688.445
+      },
+      "target_dir": "target/release-profile-bench/z"
+    },
+    {
+      "benchmark": {
+        "benchmark": "heimlern-bandits.feedback_paths.v1",
+        "cap": 1000,
+        "fill_cap": 1000,
+        "iterations": 200000,
+        "replay_iterations": 5000,
+        "samples": [
+          {
+            "existing_slot_ns_per_call": 21.777275,
+            "existing_slot_total_ns": 4355455,
+            "filling_slots_ns_per_call": 1489.238,
+            "filling_slots_total_ns": 1489238,
+            "sample": 1,
+            "snapshot_replay_ns_per_call": 307381.717,
+            "snapshot_replay_total_ns": 1536908585
+          },
+          {
+            "existing_slot_ns_per_call": 20.41042,
+            "existing_slot_total_ns": 4082084,
+            "filling_slots_ns_per_call": 1320.167,
+            "filling_slots_total_ns": 1320167,
+            "sample": 2,
+            "snapshot_replay_ns_per_call": 237552.617,
+            "snapshot_replay_total_ns": 1187763085
+          },
+          {
+            "existing_slot_ns_per_call": 21.674825,
+            "existing_slot_total_ns": 4334965,
+            "filling_slots_ns_per_call": 1401.828,
+            "filling_slots_total_ns": 1401828,
+            "sample": 3,
+            "snapshot_replay_ns_per_call": 235578.2636,
+            "snapshot_replay_total_ns": 1177891318
+          }
+        ],
+        "warmup": 1000
+      },
+      "binary": "target/release-profile-bench/s/release/examples/bench_feedback",
+      "binary_size_bytes": 535680,
+      "build_seconds": 2.3984037109767087,
+      "build_stderr_tail": "   Compiling heimlern-bandits v0.1.0 (/home/alex/repos/.heimlern-worktrees/opt-profile-benchmark-v1/crates/heimlern-bandits)\n    Finished `release` profile [optimized] target(s) in 2.36s",
+      "cargo_profile_release_opt_level": "s",
+      "profile": "s",
+      "summary": {
+        "existing_slot_ns_per_call_median": 21.674825,
+        "filling_slots_ns_per_call_median": 1401.828,
+        "snapshot_replay_ns_per_call_median": 237552.617
+      },
+      "target_dir": "target/release-profile-bench/s"
+    },
+    {
+      "benchmark": {
+        "benchmark": "heimlern-bandits.feedback_paths.v1",
+        "cap": 1000,
+        "fill_cap": 1000,
+        "iterations": 200000,
+        "replay_iterations": 5000,
+        "samples": [
+          {
+            "existing_slot_ns_per_call": 20.84122,
+            "existing_slot_total_ns": 4168244,
+            "filling_slots_ns_per_call": 1440.558,
+            "filling_slots_total_ns": 1440558,
+            "sample": 1,
+            "snapshot_replay_ns_per_call": 285718.3568,
+            "snapshot_replay_total_ns": 1428591784
+          },
+          {
+            "existing_slot_ns_per_call": 19.73496,
+            "existing_slot_total_ns": 3946992,
+            "filling_slots_ns_per_call": 1341.778,
+            "filling_slots_total_ns": 1341778,
+            "sample": 2,
+            "snapshot_replay_ns_per_call": 218003.675,
+            "snapshot_replay_total_ns": 1090018375
+          },
+          {
+            "existing_slot_ns_per_call": 19.64421,
+            "existing_slot_total_ns": 3928842,
+            "filling_slots_ns_per_call": 1362.578,
+            "filling_slots_total_ns": 1362578,
+            "sample": 3,
+            "snapshot_replay_ns_per_call": 217404.4736,
+            "snapshot_replay_total_ns": 1087022368
+          }
+        ],
+        "warmup": 1000
+      },
+      "binary": "target/release-profile-bench/3/release/examples/bench_feedback",
+      "binary_size_bytes": 579272,
+      "build_seconds": 2.789217390003614,
+      "build_stderr_tail": "   Compiling heimlern-bandits v0.1.0 (/home/alex/repos/.heimlern-worktrees/opt-profile-benchmark-v1/crates/heimlern-bandits)\n    Finished `release` profile [optimized] target(s) in 2.75s",
+      "cargo_profile_release_opt_level": "3",
+      "profile": "3",
+      "summary": {
+        "existing_slot_ns_per_call_median": 19.73496,
+        "filling_slots_ns_per_call_median": 1362.578,
+        "snapshot_replay_ns_per_call_median": 218003.675
+      },
+      "target_dir": "target/release-profile-bench/3"
+    }
+  ],
+  "schema_version": 1
+}

--- a/scripts/benchmark_release_profiles.py
+++ b/scripts/benchmark_release_profiles.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Benchmark Heimlern release opt-level profiles.
+
+The script builds the existing `heimlern-bandits` feedback benchmark with isolated
+Cargo target directories and `CARGO_PROFILE_RELEASE_OPT_LEVEL` set to each
+requested profile. It then records binary size and benchmark timings as JSON.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import platform
+import statistics
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_OUTPUT = ROOT / "docs" / "benchmarks" / "release-profile-comparison.latest.json"
+BENCH_EXAMPLE = "bench_feedback"
+BENCH_PACKAGE = "heimlern-bandits"
+
+
+def run(cmd: list[str], *, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        cmd,
+        cwd=ROOT,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=True,
+    )
+
+
+def median(values: list[float]) -> float:
+    return float(statistics.median(values))
+
+
+def build_and_run_profile(profile: str, args: argparse.Namespace) -> dict[str, Any]:
+    target_dir = ROOT / "target" / "release-profile-bench" / profile
+    env = os.environ.copy()
+    env["CARGO_TARGET_DIR"] = str(target_dir)
+    env["CARGO_PROFILE_RELEASE_OPT_LEVEL"] = profile
+
+    started = time.perf_counter()
+    build = run(
+        [
+            "cargo",
+            "build",
+            "--release",
+            "-p",
+            BENCH_PACKAGE,
+            "--example",
+            BENCH_EXAMPLE,
+        ],
+        env=env,
+    )
+    build_seconds = time.perf_counter() - started
+
+    binary = target_dir / "release" / "examples" / BENCH_EXAMPLE
+    if sys.platform.startswith("win"):
+        binary = binary.with_suffix(".exe")
+    if not binary.is_file():
+        raise SystemExit(f"built benchmark binary not found: {binary}")
+
+    bench = run(
+        [
+            str(binary),
+            "--json",
+            "--iterations",
+            str(args.iterations),
+            "--replay-iterations",
+            str(args.replay_iterations),
+            "--fill-cap",
+            str(args.fill_cap),
+            "--warmup",
+            str(args.warmup),
+            "--samples",
+            str(args.samples),
+        ],
+        env=env,
+    )
+    report = json.loads(bench.stdout)
+    samples = report["samples"]
+    return {
+        "profile": profile,
+        "cargo_profile_release_opt_level": profile,
+        "target_dir": str(target_dir.relative_to(ROOT)),
+        "binary": str(binary.relative_to(ROOT)),
+        "binary_size_bytes": binary.stat().st_size,
+        "build_seconds": build_seconds,
+        "benchmark": report,
+        "summary": {
+            "existing_slot_ns_per_call_median": median(
+                [float(s["existing_slot_ns_per_call"]) for s in samples]
+            ),
+            "filling_slots_ns_per_call_median": median(
+                [float(s["filling_slots_ns_per_call"]) for s in samples]
+            ),
+            "snapshot_replay_ns_per_call_median": median(
+                [float(s["snapshot_replay_ns_per_call"]) for s in samples]
+            ),
+        },
+        "build_stderr_tail": "\n".join(build.stderr.splitlines()[-20:]),
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--profiles",
+        default="z,s,3",
+        help="Comma-separated opt-level profiles to compare, default: z,s,3",
+    )
+    parser.add_argument("--iterations", type=int, default=200_000)
+    parser.add_argument("--replay-iterations", type=int, default=10_000)
+    parser.add_argument("--fill-cap", type=int, default=1_000)
+    parser.add_argument("--warmup", type=int, default=1_000)
+    parser.add_argument("--samples", type=int, default=3)
+    parser.add_argument("--out", type=Path, default=DEFAULT_OUTPUT)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    profiles = [item.strip() for item in args.profiles.split(",") if item.strip()]
+    if not profiles:
+        raise SystemExit("at least one profile is required")
+    args.out = args.out if args.out.is_absolute() else ROOT / args.out
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+
+    generated_at = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    git_head = run(["git", "rev-parse", "HEAD"], env=os.environ.copy()).stdout.strip()
+    git_dirty = bool(run(["git", "status", "--short"], env=os.environ.copy()).stdout.strip())
+
+    results = [build_and_run_profile(profile, args) for profile in profiles]
+    smallest = min(results, key=lambda item: int(item["binary_size_bytes"]))
+    fastest_existing = min(
+        results,
+        key=lambda item: float(item["summary"]["existing_slot_ns_per_call_median"]),
+    )
+
+    output = {
+        "schema_version": 1,
+        "kind": "heimlern.release_profile_benchmark.v1",
+        "generated_at": generated_at,
+        "git_head": git_head,
+        "git_dirty": git_dirty,
+        "command": {
+            "profiles": profiles,
+            "iterations": args.iterations,
+            "replay_iterations": args.replay_iterations,
+            "fill_cap": args.fill_cap,
+            "warmup": args.warmup,
+            "samples": args.samples,
+        },
+        "host": {
+            "platform": platform.platform(),
+            "processor": platform.processor(),
+            "python": platform.python_version(),
+        },
+        "results": results,
+        "decision_inputs": {
+            "smallest_binary_profile": smallest["profile"],
+            "fastest_existing_slot_profile": fastest_existing["profile"],
+        },
+        "does_not_establish": [
+            "production_runtime_performance",
+            "all_workload_performance",
+            "cross_machine_reproducibility",
+            "policy_quality",
+            "learning_quality",
+        ],
+    }
+    args.out.write_text(json.dumps(output, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps({"out": str(args.out), "profiles": profiles}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Implements `HEIMLERN-OPTIMIZATION-V1-T004`: release-profile measurement and decision.

Changes:

- makes `bench_feedback` reproducible and JSON-capable;
- adds `scripts/benchmark_release_profiles.py` to compare release `opt-level` profiles with isolated Cargo target dirs;
- records raw benchmark evidence in `docs/benchmarks/release-profile-comparison-2026-07-08.json`;
- adds ADR-0004 and updates the ADR index;
- changes workspace `[profile.release]` from `opt-level = "z"` to `opt-level = "s"`.

## Decision

Use `opt-level = "s"`.

Measured profile comparison:

| opt-level | binary size bytes | existing-slot ns/call median | fill-slots ns/call median | snapshot-replay ns/call median |
| --- | ---: | ---: | ---: | ---: |
| `z` | 538056 | 30.489175 | 1339.547000 | 284688.445000 |
| `s` | 535680 | 21.674825 | 1401.828000 | 237552.617000 |
| `3` | 579272 | 19.734960 | 1362.578000 | 218003.675000 |

Rationale: `s` is the smallest measured binary and materially faster than `z` on existing-slot feedback and snapshot replay. `3` is fastest but larger, so it does not fit the current size-conscious release premise.

## Self-review

- The benchmark originally included a mass rejection path, but that produced stderr warnings and would have measured logging overhead. It was replaced with a snapshot replay path.
- The benchmark now prepares the existing slot without touching the warned default-slot recovery path.
- The raw report records `git_dirty=true` because the benchmark was run in the implementation worktree before commit; the source files and ADR are committed with the report so the run remains inspectable and reproducible.
- The decision does not claim production runtime performance, all-workload performance, cross-machine reproducibility, learning quality, policy quality, or future optimality.

## Validation

```text
cargo fmt --check
cargo check -p heimlern-bandits --example bench_feedback
cargo test
cargo clippy --workspace --all-targets -- -D warnings
python3 -m py_compile scripts/benchmark_release_profiles.py
python3 -m json.tool docs/benchmarks/release-profile-comparison-2026-07-08.json
python3 scripts/benchmark_release_profiles.py --profiles s --iterations 1000 --replay-iterations 100 --fill-cap 20 --warmup 10 --samples 1 --out /tmp/heimlern-release-profile-smoke.json
python3 -m json.tool /tmp/heimlern-release-profile-smoke.json
git diff --check
```
