### PR TITLE
docs: add minimal claim evidence registry

### DIFF
--- a/docs/doc-freshness-registry.md
+++ b/docs/doc-freshness-registry.md
@@ -1,0 +1,18 @@
+# Heimlern doc-freshness registry
+
+`docs/doc-freshness-registry.yml` is a minimal RepoBrief/rLens claim-evidence surface for heimlern.
+
+It records only audited, agent-relevant claims from the RepoBrief audit plan:
+
+- contract ownership boundary;
+- learning-cycle proposal gate;
+- no-auto-apply boundary;
+- weight-adjustment proposal output;
+- offline Chronik/Grabowski-style outcome ingest;
+- metrics workflow contract wiring.
+
+## Boundary
+
+The registry is not a general documentation list. A listed claim does not prove production readiness, runtime correctness, proposal quality, task completion, merge readiness or that RepoBrief/rLens is a source of task truth.
+
+RepoBrief/rLens may consume the registry as a claim-evidence navigation surface. The canonical source remains the referenced code, contracts, fixtures, tests and documentation.

--- a/docs/doc-freshness-registry.yml
+++ b/docs/doc-freshness-registry.yml
@@ -1,0 +1,146 @@
+# Heimlern doc-freshness registry v1
+#
+# Minimal, hand-authored Claim-Evidence surface for RepoBrief/rLens.
+# This file tracks only load-bearing, agent-relevant claims from the
+# heimlern RepoBrief audit plan. It is not a general documentation index.
+
+kind: heimlern.doc_freshness_registry
+version: "1.0"
+authority: diagnostic_signal
+risk_class: diagnostic
+scope: audited_agent_relevant_claims_only
+does_not_prove:
+  - "a listed claim is complete or sufficient for production use"
+  - "all heimlern documentation is current"
+  - "runtime correctness"
+  - "task completion"
+  - "merge readiness"
+  - "RepoBrief or rLens is a source of task truth"
+
+entries:
+  - id: contract-ownership-boundary
+    doc: contracts/README.md
+    locator: "Contract Ownership & Architecture"
+    claim: "heimlern owns its local policy, feedback and aussen schemas while consuming decision.outcome.v1 and policy.weight_adjustment.v1 from metarepo."
+    status: done
+    normative: true
+    owner: contracts
+    last_verified: "2026-07-08"
+    evidence:
+      - kind: text
+        target: "contracts/README.md::Contract Ownership & Architecture"
+      - kind: file
+        target: "contracts/policy.snapshot.schema.json"
+      - kind: file
+        target: "contracts/policy.decision.schema.json"
+      - kind: file
+        target: "contracts/policy.feedback.schema.json"
+      - kind: file
+        target: "contracts/aussen.event.schema.json"
+    notes: >-
+      The consumed metarepo contracts are referenced as external authority; this
+      repo does not become their schema owner.
+
+  - id: learning-cycle-proposal-gate
+    doc: docs/learning-cycle.md
+    locator: "Phasen 1-8"
+    claim: "heimlern sits in a delayed evidence-to-proposal learning loop between outcomes and a separate hausKI or human decision gate."
+    status: done
+    normative: true
+    owner: learning-cycle
+    last_verified: "2026-07-08"
+    evidence:
+      - kind: text
+        target: "docs/learning-cycle.md::Phasen"
+      - kind: text
+        target: "docs/operator-ecosystem-alignment.md::evidence -> outcome analysis -> auditable proposal -> separate decision gate"
+    notes: >-
+      This describes the intended control loop and does not prove that the
+      end-to-end runtime path is deployed.
+
+  - id: no-auto-apply-boundary
+    doc: docs/learning-cycle.md
+    locator: "Sicherheitsmechanismen / No Auto-Apply"
+    claim: "heimlern must not silently apply live policy or routing changes; it analyzes and proposes only."
+    status: done
+    normative: true
+    owner: safety
+    last_verified: "2026-07-08"
+    evidence:
+      - kind: text
+        target: "docs/learning-cycle.md::No Auto-Apply"
+      - kind: text
+        target: "docs/operator-ecosystem-alignment.md::Heimlern may propose adjustments; it must not silently apply them."
+      - kind: text
+        target: "crates/heimlern-feedback/README.md::No Direct Weight Modification"
+      - kind: text
+        target: "scripts/ola_probe.py::automatic_rule_change_permission"
+    notes: >-
+      This is a boundary claim. It does not by itself prove all future code paths
+      preserve the boundary.
+
+  - id: weight-adjustment-output
+    doc: crates/heimlern-feedback/README.md
+    locator: "Output / Contracts"
+    claim: "heimlern-feedback emits evidence-backed weight adjustment proposals for review rather than mutating live weights."
+    status: done
+    normative: true
+    owner: heimlern-feedback
+    last_verified: "2026-07-08"
+    evidence:
+      - kind: symbol
+        target: "crates/heimlern-feedback/src/lib.rs::WeightAdjustmentProposal"
+      - kind: symbol
+        target: "crates/heimlern-feedback/src/lib.rs::Evidence"
+      - kind: text
+        target: "crates/heimlern-feedback/README.md::Weight Adjustment Proposals"
+      - kind: fixture
+        target: "tests/fixtures/feedback/adjustment.ok.json"
+      - kind: test
+        target: "scripts/validate_weight_adjustment_coherence.py"
+    notes: >-
+      This proves the proposal surface exists and is bounded by evidence; it does
+      not prove proposal quality or suitability for automatic application.
+
+  - id: chronik-routing-outcome-ingest
+    doc: docs/operator-ecosystem-alignment.md
+    locator: "Operator ecosystem alignment"
+    claim: "heimlern can consume redacted Grabowski or Chronik-style outcomes as offline learning inputs without receiving live routing authority."
+    status: done
+    normative: false
+    owner: operator-learning-axis
+    last_verified: "2026-07-08"
+    evidence:
+      - kind: symbol
+        target: "scripts/ola_adapter.py::adapt"
+      - kind: symbol
+        target: "scripts/ola_adapter.py::to_decision_outcome"
+      - kind: symbol
+        target: "scripts/ola_probe.py::probe"
+      - kind: fixture
+        target: "tests/fixtures/ola/success.ok.json"
+      - kind: fixture
+        target: "tests/fixtures/ola/failed.ok.json"
+      - kind: fixture
+        target: "tests/fixtures/ola/failclosed.ok.json"
+    notes: >-
+      This is an offline observation/proposal path, not live routing control.
+
+  - id: metrics-workflow-local-contract
+    doc: .github/workflows/metrics.yml
+    locator: "Metrics Snapshot & Validation"
+    claim: "The metrics workflow generates metrics.json and validates it against the repository-local metrics.snapshot schema."
+    status: done
+    normative: false
+    owner: metrics
+    last_verified: "2026-07-08"
+    evidence:
+      - kind: workflow
+        target: ".github/workflows/metrics.yml"
+      - kind: script
+        target: "scripts/wgx-metrics-snapshot.sh"
+      - kind: schema
+        target: "contracts/metrics.snapshot.schema.json"
+    notes: >-
+      This verifies local workflow wiring only. It does not prove scheduled GitHub
+      execution, remote posting or production monitoring quality.

--- a/tests/test_doc_freshness_registry.py
+++ b/tests/test_doc_freshness_registry.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+REGISTRY = ROOT / "docs" / "doc-freshness-registry.yml"
+EXPECTED_IDS = {
+    "contract-ownership-boundary",
+    "learning-cycle-proposal-gate",
+    "no-auto-apply-boundary",
+    "weight-adjustment-output",
+    "chronik-routing-outcome-ingest",
+    "metrics-workflow-local-contract",
+}
+ALLOWED_EVIDENCE_KINDS = {
+    "file",
+    "fixture",
+    "sample",
+    "schema",
+    "script",
+    "symbol",
+    "test",
+    "text",
+    "workflow",
+}
+
+
+def _load_registry() -> dict:
+    assert REGISTRY.is_file()
+    data = yaml.safe_load(REGISTRY.read_text(encoding="utf-8"))
+    assert isinstance(data, dict)
+    return data
+
+
+def test_doc_freshness_registry_shape_and_scope() -> None:
+    data = _load_registry()
+
+    assert data["kind"] == "heimlern.doc_freshness_registry"
+    assert data["version"] == "1.0"
+    assert data["authority"] == "diagnostic_signal"
+    assert data["risk_class"] == "diagnostic"
+    assert data["scope"] == "audited_agent_relevant_claims_only"
+    assert "RepoBrief or rLens is a source of task truth" in data["does_not_prove"]
+
+    entries = data["entries"]
+    assert isinstance(entries, list)
+    assert {entry["id"] for entry in entries} == EXPECTED_IDS
+    assert len(entries) == len(EXPECTED_IDS), "registry must stay minimal, not a general doc index"
+
+
+def test_doc_freshness_registry_entries_are_bounded_and_resolvable() -> None:
+    data = _load_registry()
+
+    for entry in data["entries"]:
+        assert entry["status"] in {"done", "partial", "stale", "historical"}
+        assert entry["doc"].endswith(('.md', '.yml', '.yaml'))
+        doc_path = ROOT / entry["doc"]
+        assert doc_path.is_file(), entry["doc"]
+        assert entry["claim"].strip()
+        assert entry["notes"].strip()
+
+        evidence = entry["evidence"]
+        assert isinstance(evidence, list) and evidence
+        for item in evidence:
+            assert item["kind"] in ALLOWED_EVIDENCE_KINDS
+            target = item["target"]
+            assert isinstance(target, str) and target.strip()
+            path_part = target.split("::", 1)[0]
+            assert not path_part.startswith("/")
+            assert ".." not in Path(path_part).parts
+            assert (ROOT / path_part).exists(), target


### PR DESCRIPTION
## Summary

Implements Bureau task `HEIMLERN-OPTIMIZATION-V1-T006` by adding a minimal RepoBrief/rLens claim-evidence registry for heimlern.

Changes:

- adds `docs/doc-freshness-registry.yml` with six audited, agent-relevant claims from the RepoBrief audit plan;
- documents the registry boundary in `docs/doc-freshness-registry.md`;
- adds `tests/test_doc_freshness_registry.py` to keep the registry bounded and evidence targets resolvable.

## Self-review

- Scope is intentionally minimal: six claims only, not a general documentation index.
- Claims map to existing code, docs, contracts, fixtures, scripts or workflow files.
- The registry is a diagnostic/navigation surface only; it does not establish production readiness, runtime correctness, proposal quality, task completion, merge readiness or RepoBrief/rLens task truth.
- The Bureau task metadata references `docs/plans/heimlern-optimization-plan-v1.md`, but the live repo contains `docs/plans/heimlern-repobrief-audit-umbauplan-v1.md`; this PR follows the live plan section "PR 4 — RepoBrief Evidence Surface für heimlern".
- `just schema-validate` is already red on `origin/main` because `scripts/examples.py` emits a stale `policy.feedback` example; this PR does not touch that path and CI uses separate validation commands.

## Validation

```text
python3 -m py_compile tests/test_doc_freshness_registry.py scripts/ola_adapter.py scripts/ola_probe.py scripts/validate_json.py scripts/validate_weight_adjustment_coherence.py
python3 -m pytest -q tests/test_doc_freshness_registry.py
python3 scripts/validate_json.py --schemas contracts/ --samples data/samples/
python3 scripts/validate_json.py contracts/policy.feedback.schema.json data/samples/policy.feedback.rejected.json  # expected failure
python3 scripts/ola_adapter.py --self-test
for input in tests/fixtures/ola/*.ok.json; do
  python3 scripts/ola_adapter.py "$input" > /tmp/ola-routing-outcome.json
  python3 scripts/validate_json.py contracts/operator.routing_outcome.v1.schema.json /tmp/ola-routing-outcome.json
  python3 scripts/ola_adapter.py --emit decision-outcome "$input" > /tmp/ola-decision-outcome.json
  python3 -m json.tool /tmp/ola-decision-outcome.json >/dev/null
done
python3 scripts/ola_probe.py --self-test
python3 scripts/ola_probe.py > /tmp/ola-probe.json
python3 -m json.tool /tmp/ola-probe.json >/dev/null
python3 - <<'PY'
from pathlib import Path
import yaml
r = yaml.safe_load(Path('docs/doc-freshness-registry.yml').read_text())
assert r['kind'] == 'heimlern.doc_freshness_registry'
assert len(r['entries']) == 6
PY
cargo fmt --all --check
cargo clippy --all-targets -- -D warnings
cargo test --all --locked --workspace
git diff --check
```
