### PR TITLE
feat: move OLA adapter invariants into Rust

### DIFF
--- a/crates/heimlern-feedback/src/lib.rs
+++ b/crates/heimlern-feedback/src/lib.rs
@@ -23,6 +23,8 @@
 //! whether they were "explore" or "exploit" decisions. Simulation is supported for
 //! [`DeltaValue::Relative`], [`DeltaValue::Additive`], and [`DeltaValue::Absolute`] adjustments to `epsilon`.
 
+pub mod ola_adapter;
+
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use time::{format_description::well_known::Rfc3339, OffsetDateTime};
@@ -428,7 +430,7 @@ impl FeedbackAnalyzer {
     ///
     /// *   **epsilon**:
     ///     *   `DeltaValue::Additive`: Legacy simulation-only change to the exploration rate.
-    ///     *   `DeltaValue::Absolute`: Sets the target exploration probability (`P(explore)`).
+    ///     *   `DeltaValue::Absolute`: Sets the target exploration probability (`P(explore`).
     ///     *   `DeltaValue::Relative { unit: "percent" }`: Scales the current exploration fraction
     ///         by `1.0 + value / 100.0`.
     ///     *   `DeltaValue::Relative { unit: "factor" }`: Scales the current exploration fraction
@@ -1266,22 +1268,19 @@ mod tests {
         let analyzer = FeedbackAnalyzer::default();
         let outcomes: Vec<DecisionOutcome> = (0..10)
             .map(|i| {
-                // 50/50 split
                 let is_exploit = i % 2 == 0;
-                let strategy = if is_exploit { "exploit" } else { "explore ε" };
                 create_outcome(
                     &i.to_string(),
                     "action",
-                    true, // All success
-                    1.0,
-                    Some(strategy),
+                    is_exploit,
+                    if is_exploit { 1.0 } else { 0.0 },
+                    Some(if is_exploit { "exploit" } else { "explore ε" }),
                 )
             })
             .collect();
 
-        // Huge delta to force clamp
         let mut deltas = HashMap::new();
-        deltas.insert("epsilon".to_string(), DeltaValue::Additive { value: 10.0 });
+        deltas.insert("epsilon".to_string(), DeltaValue::Additive { value: -2.0 });
 
         let proposal = WeightAdjustmentProposal {
             version: "legacy-simulation".to_string(),
@@ -1294,95 +1293,8 @@ mod tests {
             status: ProposalStatus::Proposed,
         };
 
-        // All success, so rate should stay 1.0 regardless of mix
+        // Should clamp exploration to 0.0, all exploit -> success rate 1.0
         let simulated_rate = analyzer.simulate_adjustment(&proposal, &outcomes);
         assert!((simulated_rate - 1.0).abs() < 1e-5);
-    }
-
-    #[test]
-    fn simulation_handles_unknown_strategies() {
-        let analyzer = FeedbackAnalyzer::default();
-        let outcomes: Vec<DecisionOutcome> = (0..10)
-            .map(|i| {
-                // No strategy metadata
-                create_outcome(
-                    &i.to_string(),
-                    "action",
-                    i % 2 == 0, // 50% success
-                    if i % 2 == 0 { 1.0 } else { 0.0 },
-                    None,
-                )
-            })
-            .collect();
-
-        let mut deltas = HashMap::new();
-        deltas.insert("epsilon".to_string(), DeltaValue::Additive { value: -0.1 });
-        let proposal = WeightAdjustmentProposal {
-            version: "legacy-simulation".to_string(),
-            basis_policy: "test".to_string(),
-            ts: iso8601_now(),
-            deltas,
-            confidence: 0.7,
-            evidence: Evidence::default(),
-            reasoning: None,
-            status: ProposalStatus::Proposed,
-        };
-
-        // Should return baseline (0.5) because known_total is 0
-        let simulated_rate = analyzer.simulate_adjustment(&proposal, &outcomes);
-        assert!((simulated_rate - 0.5).abs() < 1e-5);
-    }
-
-    #[test]
-    fn simulation_handles_mixed_known_unknown() {
-        let analyzer = FeedbackAnalyzer::default();
-        let mut outcomes = Vec::new();
-
-        // 10 Known: 5 Exploit (Success), 5 Explore (Failure) -> Rate 0.5
-        for i in 0..10 {
-            let is_exploit = i % 2 == 0;
-            let strategy = if is_exploit { "exploit" } else { "explore ε" };
-            outcomes.push(create_outcome(
-                &i.to_string(),
-                "a",
-                is_exploit,
-                if is_exploit { 1.0 } else { 0.0 },
-                Some(strategy),
-            ));
-        }
-
-        // 10 Unknown: All Success -> Rate 1.0
-        for i in 10..20 {
-            outcomes.push(create_outcome(&i.to_string(), "b", true, 1.0, None));
-        }
-
-        // Total decisions: 20
-        // Known: 10. Current Explore Ratio: 0.5.
-        // Proposal: Delta -0.1 -> New Explore Ratio 0.4.
-        // New Known Success Rate: 0.6 (calculated in previous test logic: 0.6*1.0 + 0.4*0.0)
-        // Expected Success Count (Known) = 0.6 * 10 = 6.
-        // Unknown Success Count = 10 (unchanged).
-        // Total Success = 16.
-        // Total Rate = 16 / 20 = 0.8.
-
-        let mut deltas = HashMap::new();
-        deltas.insert("epsilon".to_string(), DeltaValue::Additive { value: -0.1 });
-        let proposal = WeightAdjustmentProposal {
-            version: "legacy-simulation".to_string(),
-            basis_policy: "test".to_string(),
-            ts: iso8601_now(),
-            deltas,
-            confidence: 0.7,
-            evidence: Evidence::default(),
-            reasoning: None,
-            status: ProposalStatus::Proposed,
-        };
-
-        let simulated_rate = analyzer.simulate_adjustment(&proposal, &outcomes);
-        assert!(
-            (simulated_rate - 0.8).abs() < 1e-5,
-            "Expected 0.8, got {}",
-            simulated_rate
-        );
     }
 }

--- a/crates/heimlern-feedback/src/ola_adapter.rs
+++ b/crates/heimlern-feedback/src/ola_adapter.rs
@@ -234,14 +234,8 @@ mod tests {
 
     #[test]
     fn states_normalize_with_unknown_fallback() {
-        assert_eq!(
-            normalize_completion_state(Some("completed")),
-            CompletionState::Completed
-        );
-        assert_eq!(
-            normalize_completion_state(Some("bogus")),
-            CompletionState::Unknown
-        );
+        assert_eq!(normalize_completion_state(Some("completed")), CompletionState::Completed);
+        assert_eq!(normalize_completion_state(Some("bogus")), CompletionState::Unknown);
         assert_eq!(normalize_ci_state(Some("pass")), CiState::Pass);
         assert_eq!(normalize_ci_state(None), CiState::Unknown);
         assert_eq!(normalize_pr_state(Some("merged")), PrState::Merged);
@@ -250,26 +244,11 @@ mod tests {
 
     #[test]
     fn outcome_classification_matches_probe_boundary() {
-        assert_eq!(
-            classify_outcome(CompletionState::Completed, 0),
-            OutcomeType::Success
-        );
-        assert_eq!(
-            classify_outcome(CompletionState::Failed, 0),
-            OutcomeType::Failure
-        );
-        assert_eq!(
-            classify_outcome(CompletionState::Blocked, 0),
-            OutcomeType::Partial
-        );
-        assert_eq!(
-            classify_outcome(CompletionState::Unknown, 1),
-            OutcomeType::Partial
-        );
-        assert_eq!(
-            classify_outcome(CompletionState::Unknown, 0),
-            OutcomeType::Unknown
-        );
+        assert_eq!(classify_outcome(CompletionState::Completed, 0), OutcomeType::Success);
+        assert_eq!(classify_outcome(CompletionState::Failed, 0), OutcomeType::Failure);
+        assert_eq!(classify_outcome(CompletionState::Blocked, 0), OutcomeType::Partial);
+        assert_eq!(classify_outcome(CompletionState::Unknown, 1), OutcomeType::Partial);
+        assert_eq!(classify_outcome(CompletionState::Unknown, 0), OutcomeType::Unknown);
     }
 
     #[test]

--- a/crates/heimlern-feedback/src/ola_adapter.rs
+++ b/crates/heimlern-feedback/src/ola_adapter.rs
@@ -87,7 +87,10 @@ pub fn route_delta_key(action: &str) -> Result<(String, String), RouteDeltaKeyEr
     if route.is_empty() {
         return Err(RouteDeltaKeyError::EmptyRoute);
     }
-    Ok((format!("route.{}.weight", safe_route(route)), route.to_string()))
+    Ok((
+        format!("route.{}.weight", safe_route(route)),
+        route.to_string(),
+    ))
 }
 
 /// Clamp finite rewards to the contract boundary and round to three decimals.
@@ -194,7 +197,10 @@ mod tests {
         assert_eq!(safe_route("direct/patch/v2"), "direct_patch_v2");
         assert_eq!(safe_route("direct_patch"), "direct_patch");
         assert_eq!(safe_route("foo__bar"), "foo__bar");
-        assert_eq!(safe_route("route.with.dots-and-dashes"), "route.with.dots-and-dashes");
+        assert_eq!(
+            safe_route("route.with.dots-and-dashes"),
+            "route.with.dots-and-dashes"
+        );
         assert_eq!(safe_route("röute"), "r_ute");
         assert_eq!(safe_route("中"), "unknown_route");
     }
@@ -203,7 +209,10 @@ mod tests {
     fn route_delta_key_fails_closed() {
         assert_eq!(
             route_delta_key("route.direct:patch"),
-            Ok(("route.direct_patch.weight".to_string(), "direct:patch".to_string()))
+            Ok((
+                "route.direct_patch.weight".to_string(),
+                "direct:patch".to_string()
+            ))
         );
         assert_eq!(
             route_delta_key("direct_patch"),
@@ -222,8 +231,14 @@ mod tests {
 
     #[test]
     fn states_normalize_with_unknown_fallback() {
-        assert_eq!(normalize_completion_state(Some("completed")), CompletionState::Completed);
-        assert_eq!(normalize_completion_state(Some("bogus")), CompletionState::Unknown);
+        assert_eq!(
+            normalize_completion_state(Some("completed")),
+            CompletionState::Completed
+        );
+        assert_eq!(
+            normalize_completion_state(Some("bogus")),
+            CompletionState::Unknown
+        );
         assert_eq!(normalize_ci_state(Some("pass")), CiState::Pass);
         assert_eq!(normalize_ci_state(None), CiState::Unknown);
         assert_eq!(normalize_pr_state(Some("merged")), PrState::Merged);
@@ -232,11 +247,26 @@ mod tests {
 
     #[test]
     fn outcome_classification_matches_probe_boundary() {
-        assert_eq!(classify_outcome(CompletionState::Completed, 0), OutcomeType::Success);
-        assert_eq!(classify_outcome(CompletionState::Failed, 0), OutcomeType::Failure);
-        assert_eq!(classify_outcome(CompletionState::Blocked, 0), OutcomeType::Partial);
-        assert_eq!(classify_outcome(CompletionState::Unknown, 1), OutcomeType::Partial);
-        assert_eq!(classify_outcome(CompletionState::Unknown, 0), OutcomeType::Unknown);
+        assert_eq!(
+            classify_outcome(CompletionState::Completed, 0),
+            OutcomeType::Success
+        );
+        assert_eq!(
+            classify_outcome(CompletionState::Failed, 0),
+            OutcomeType::Failure
+        );
+        assert_eq!(
+            classify_outcome(CompletionState::Blocked, 0),
+            OutcomeType::Partial
+        );
+        assert_eq!(
+            classify_outcome(CompletionState::Unknown, 1),
+            OutcomeType::Partial
+        );
+        assert_eq!(
+            classify_outcome(CompletionState::Unknown, 0),
+            OutcomeType::Unknown
+        );
     }
 
     #[test]

--- a/crates/heimlern-feedback/src/ola_adapter.rs
+++ b/crates/heimlern-feedback/src/ola_adapter.rs
@@ -1,0 +1,268 @@
+//! Rust-owned OPERATOR-LEARNING adapter invariants.
+//!
+//! The Python OLA scripts remain probe and compatibility surfaces. This module
+//! keeps the safety-critical adapter transformations in the tested Rust core so
+//! route delta key construction, state normalization and reward bounds are not
+//! owned primarily by script-local helper functions.
+
+use crate::OutcomeType;
+
+const REWARD_MIN: f32 = -1.0;
+const REWARD_MAX: f32 = 1.0;
+
+/// Route delta key validation failures.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RouteDeltaKeyError {
+    InvalidActionPrefix,
+    EmptyRoute,
+}
+
+/// Completion states accepted by the OLA adapter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CompletionState {
+    Completed,
+    Blocked,
+    Deferred,
+    Failed,
+    Unknown,
+}
+
+/// CI states accepted by the OLA adapter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CiState {
+    Pass,
+    Fail,
+    Pending,
+    NotApplicable,
+    Unknown,
+}
+
+/// Pull request states accepted by the OLA adapter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PrState {
+    Merged,
+    Open,
+    Closed,
+    NotApplicable,
+    Unknown,
+}
+
+/// Numeric reward calculation inputs used by the OLA adapter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RewardInputs {
+    pub completion_state: CompletionState,
+    pub friction_count: u8,
+    pub unresolved_friction: u8,
+    pub blocked_by_platform_filter: bool,
+    pub manual_operator_needed: bool,
+    pub ci_state: CiState,
+    pub pr_state: PrState,
+    pub rework_count: u8,
+}
+
+/// Convert any route label to the safe key fragment used in v1 delta keys.
+#[must_use]
+pub fn safe_route(value: &str) -> String {
+    let mut result = String::with_capacity(value.len());
+    for ch in value.chars() {
+        if ch.is_ascii_alphanumeric() || matches!(ch, '.' | '_' | '-') {
+            result.push(ch);
+        } else {
+            result.push('_');
+        }
+    }
+    let normalized = result.trim_matches(['.', '_', '-']);
+    if normalized.is_empty() {
+        "unknown_route".to_string()
+    } else {
+        normalized.to_string()
+    }
+}
+
+/// Build the contract-bound route weight delta key from a `route.*` action.
+pub fn route_delta_key(action: &str) -> Result<(String, String), RouteDeltaKeyError> {
+    let Some(route) = action.strip_prefix("route.") else {
+        return Err(RouteDeltaKeyError::InvalidActionPrefix);
+    };
+    if route.is_empty() {
+        return Err(RouteDeltaKeyError::EmptyRoute);
+    }
+    Ok((format!("route.{}.weight", safe_route(route)), route.to_string()))
+}
+
+/// Clamp finite rewards to the contract boundary and round to three decimals.
+#[must_use]
+pub fn clamp_reward(value: f32) -> f32 {
+    if !value.is_finite() {
+        return 0.0;
+    }
+    let rounded = (value * 1000.0).round() / 1000.0;
+    rounded.clamp(REWARD_MIN, REWARD_MAX)
+}
+
+/// Normalize completion state strings with a fail-closed unknown fallback.
+#[must_use]
+pub fn normalize_completion_state(value: Option<&str>) -> CompletionState {
+    match value {
+        Some("completed") => CompletionState::Completed,
+        Some("blocked") => CompletionState::Blocked,
+        Some("deferred") => CompletionState::Deferred,
+        Some("failed") => CompletionState::Failed,
+        Some("unknown") => CompletionState::Unknown,
+        _ => CompletionState::Unknown,
+    }
+}
+
+/// Normalize CI state strings with a fail-closed unknown fallback.
+#[must_use]
+pub fn normalize_ci_state(value: Option<&str>) -> CiState {
+    match value {
+        Some("pass") => CiState::Pass,
+        Some("fail") => CiState::Fail,
+        Some("pending") => CiState::Pending,
+        Some("not_applicable") => CiState::NotApplicable,
+        Some("unknown") => CiState::Unknown,
+        _ => CiState::Unknown,
+    }
+}
+
+/// Normalize pull request state strings with a fail-closed unknown fallback.
+#[must_use]
+pub fn normalize_pr_state(value: Option<&str>) -> PrState {
+    match value {
+        Some("merged") => PrState::Merged,
+        Some("open") => PrState::Open,
+        Some("closed") => PrState::Closed,
+        Some("not_applicable") => PrState::NotApplicable,
+        Some("unknown") => PrState::Unknown,
+        _ => PrState::Unknown,
+    }
+}
+
+/// Classify a normalized OLA completion state into a decision outcome.
+#[must_use]
+pub fn classify_outcome(completion_state: CompletionState, unresolved_friction: u8) -> OutcomeType {
+    match completion_state {
+        CompletionState::Completed => OutcomeType::Success,
+        CompletionState::Failed => OutcomeType::Failure,
+        CompletionState::Blocked | CompletionState::Deferred => OutcomeType::Partial,
+        CompletionState::Unknown if unresolved_friction > 0 => OutcomeType::Partial,
+        CompletionState::Unknown => OutcomeType::Unknown,
+    }
+}
+
+/// Compute the bounded OLA reward from normalized adapter inputs.
+#[must_use]
+pub fn compute_reward(inputs: RewardInputs) -> f32 {
+    let mut reward = match inputs.completion_state {
+        CompletionState::Completed => 0.7,
+        CompletionState::Blocked => -0.35,
+        CompletionState::Deferred => -0.1,
+        CompletionState::Failed => -0.75,
+        CompletionState::Unknown => 0.0,
+    };
+    reward -= f32::from(inputs.friction_count.min(5)) * 0.05;
+    reward -= f32::from(inputs.unresolved_friction.min(5)) * 0.1;
+    if inputs.blocked_by_platform_filter {
+        reward -= 0.1;
+    }
+    if inputs.manual_operator_needed {
+        reward -= 0.15;
+    }
+    match inputs.ci_state {
+        CiState::Pass => reward += 0.1,
+        CiState::Fail => reward -= 0.2,
+        CiState::Pending | CiState::NotApplicable | CiState::Unknown => {}
+    }
+    match inputs.pr_state {
+        PrState::Merged => reward += 0.1,
+        PrState::Closed => reward -= 0.1,
+        PrState::Open | PrState::NotApplicable | PrState::Unknown => {}
+    }
+    reward -= f32::from(inputs.rework_count.min(5)) * 0.05;
+    clamp_reward(reward)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn safe_route_matches_ola_probe_contract() {
+        assert_eq!(safe_route(""), "unknown_route");
+        assert_eq!(safe_route("direct:patch"), "direct_patch");
+        assert_eq!(safe_route("direct/patch/v2"), "direct_patch_v2");
+        assert_eq!(safe_route("direct_patch"), "direct_patch");
+        assert_eq!(safe_route("foo__bar"), "foo__bar");
+        assert_eq!(safe_route("route.with.dots-and-dashes"), "route.with.dots-and-dashes");
+        assert_eq!(safe_route("röute"), "r_ute");
+        assert_eq!(safe_route("中"), "unknown_route");
+    }
+
+    #[test]
+    fn route_delta_key_fails_closed() {
+        assert_eq!(
+            route_delta_key("route.direct:patch"),
+            Ok(("route.direct_patch.weight".to_string(), "direct:patch".to_string()))
+        );
+        assert_eq!(
+            route_delta_key("direct_patch"),
+            Err(RouteDeltaKeyError::InvalidActionPrefix)
+        );
+        assert_eq!(route_delta_key("route."), Err(RouteDeltaKeyError::EmptyRoute));
+    }
+
+    #[test]
+    fn reward_is_rounded_and_clamped() {
+        assert_eq!(clamp_reward(1.2345), 1.0);
+        assert_eq!(clamp_reward(-2.0), -1.0);
+        assert_eq!(clamp_reward(0.1236), 0.124);
+        assert_eq!(clamp_reward(f32::NAN), 0.0);
+    }
+
+    #[test]
+    fn states_normalize_with_unknown_fallback() {
+        assert_eq!(normalize_completion_state(Some("completed")), CompletionState::Completed);
+        assert_eq!(normalize_completion_state(Some("bogus")), CompletionState::Unknown);
+        assert_eq!(normalize_ci_state(Some("pass")), CiState::Pass);
+        assert_eq!(normalize_ci_state(None), CiState::Unknown);
+        assert_eq!(normalize_pr_state(Some("merged")), PrState::Merged);
+        assert_eq!(normalize_pr_state(Some("draft")), PrState::Unknown);
+    }
+
+    #[test]
+    fn outcome_classification_matches_probe_boundary() {
+        assert_eq!(classify_outcome(CompletionState::Completed, 0), OutcomeType::Success);
+        assert_eq!(classify_outcome(CompletionState::Failed, 0), OutcomeType::Failure);
+        assert_eq!(classify_outcome(CompletionState::Blocked, 0), OutcomeType::Partial);
+        assert_eq!(classify_outcome(CompletionState::Unknown, 1), OutcomeType::Partial);
+        assert_eq!(classify_outcome(CompletionState::Unknown, 0), OutcomeType::Unknown);
+    }
+
+    #[test]
+    fn compute_reward_matches_documented_probe_formula() {
+        let reward = compute_reward(RewardInputs {
+            completion_state: CompletionState::Completed,
+            friction_count: 1,
+            unresolved_friction: 0,
+            blocked_by_platform_filter: false,
+            manual_operator_needed: false,
+            ci_state: CiState::Pass,
+            pr_state: PrState::Merged,
+            rework_count: 0,
+        });
+        assert!((reward - 0.85).abs() < f32::EPSILON);
+
+        let blocked = compute_reward(RewardInputs {
+            completion_state: CompletionState::Blocked,
+            friction_count: 9,
+            unresolved_friction: 9,
+            blocked_by_platform_filter: true,
+            manual_operator_needed: true,
+            ci_state: CiState::Fail,
+            pr_state: PrState::Closed,
+            rework_count: 9,
+        });
+        assert_eq!(blocked, -1.0);
+    }
+}

--- a/crates/heimlern-feedback/src/ola_adapter.rs
+++ b/crates/heimlern-feedback/src/ola_adapter.rs
@@ -214,7 +214,7 @@ mod tests {
             route_delta_key("route.direct:patch"),
             Ok((
                 "route.direct_patch.weight".to_string(),
-                "direct:patch".to_string()
+                "direct:patch".to_string(),
             ))
         );
         assert_eq!(

--- a/crates/heimlern-feedback/src/ola_adapter.rs
+++ b/crates/heimlern-feedback/src/ola_adapter.rs
@@ -144,7 +144,10 @@ pub fn normalize_pr_state(value: Option<&str>) -> PrState {
 
 /// Classify a normalized OLA completion state into a decision outcome.
 #[must_use]
-pub fn classify_outcome(completion_state: CompletionState, unresolved_friction: u8) -> OutcomeType {
+pub fn classify_outcome(
+    completion_state: CompletionState,
+    unresolved_friction: u8,
+) -> OutcomeType {
     match completion_state {
         CompletionState::Completed => OutcomeType::Success,
         CompletionState::Failed => OutcomeType::Failure,

--- a/crates/heimlern-feedback/tests/simulation_strategy.rs
+++ b/crates/heimlern-feedback/tests/simulation_strategy.rs
@@ -1,7 +1,10 @@
-use heimlern_feedback::{
-    DecisionOutcome, DeltaValue, Evidence, FeedbackAnalyzer, OutcomeType, ProposalStatus,
-    WeightAdjustmentProposal,
-};
+use heimlern_feedback::DecisionOutcome;
+use heimlern_feedback::DeltaValue;
+use heimlern_feedback::Evidence;
+use heimlern_feedback::FeedbackAnalyzer;
+use heimlern_feedback::OutcomeType;
+use heimlern_feedback::ProposalStatus;
+use heimlern_feedback::WeightAdjustmentProposal;
 use std::collections::HashMap;
 
 fn create_outcome(
@@ -54,17 +57,14 @@ fn simulation_handles_unknown_strategies() {
     let analyzer = FeedbackAnalyzer::default();
     let outcomes: Vec<DecisionOutcome> = (0..10)
         .map(|i| {
-            create_outcome(
-                &i.to_string(),
-                "action",
-                i % 2 == 0,
-                if i % 2 == 0 { 1.0 } else { 0.0 },
-                None,
-            )
+            let success = i % 2 == 0;
+            let reward = if success { 1.0 } else { 0.0 };
+            create_outcome(&i.to_string(), "action", success, reward, None)
         })
         .collect();
 
-    let simulated_rate = analyzer.simulate_adjustment(&additive_epsilon_proposal(-0.1), &outcomes);
+    let proposal = additive_epsilon_proposal(-0.1);
+    let simulated_rate = analyzer.simulate_adjustment(&proposal, &outcomes);
     assert!((simulated_rate - 0.5).abs() < 1e-5);
 }
 
@@ -75,12 +75,14 @@ fn simulation_handles_mixed_known_unknown() {
 
     for i in 0..10 {
         let is_exploit = i % 2 == 0;
+        let strategy = if is_exploit { "exploit" } else { "explore ε" };
+        let reward = if is_exploit { 1.0 } else { 0.0 };
         outcomes.push(create_outcome(
             &i.to_string(),
             "a",
             is_exploit,
-            if is_exploit { 1.0 } else { 0.0 },
-            Some(if is_exploit { "exploit" } else { "explore ε" }),
+            reward,
+            Some(strategy),
         ));
     }
 
@@ -88,9 +90,7 @@ fn simulation_handles_mixed_known_unknown() {
         outcomes.push(create_outcome(&i.to_string(), "b", true, 1.0, None));
     }
 
-    let simulated_rate = analyzer.simulate_adjustment(&additive_epsilon_proposal(-0.1), &outcomes);
-    assert!(
-        (simulated_rate - 0.8).abs() < 1e-5,
-        "Expected 0.8, got {simulated_rate}"
-    );
+    let proposal = additive_epsilon_proposal(-0.1);
+    let simulated_rate = analyzer.simulate_adjustment(&proposal, &outcomes);
+    assert!((simulated_rate - 0.8).abs() < 1e-5);
 }

--- a/crates/heimlern-feedback/tests/simulation_strategy.rs
+++ b/crates/heimlern-feedback/tests/simulation_strategy.rs
@@ -1,4 +1,7 @@
-use heimlern_feedback::{DecisionOutcome, DeltaValue, Evidence, FeedbackAnalyzer, OutcomeType, ProposalStatus, WeightAdjustmentProposal};
+use heimlern_feedback::{
+    DecisionOutcome, DeltaValue, Evidence, FeedbackAnalyzer, OutcomeType, ProposalStatus,
+    WeightAdjustmentProposal,
+};
 use std::collections::HashMap;
 
 fn create_outcome(

--- a/crates/heimlern-feedback/tests/simulation_strategy.rs
+++ b/crates/heimlern-feedback/tests/simulation_strategy.rs
@@ -64,7 +64,8 @@ fn simulation_handles_unknown_strategies() {
         })
         .collect();
 
-    let simulated_rate = analyzer.simulate_adjustment(&additive_epsilon_proposal(-0.1), &outcomes);
+    let simulated_rate =
+        analyzer.simulate_adjustment(&additive_epsilon_proposal(-0.1), &outcomes);
     assert!((simulated_rate - 0.5).abs() < 1e-5);
 }
 
@@ -88,7 +89,8 @@ fn simulation_handles_mixed_known_unknown() {
         outcomes.push(create_outcome(&i.to_string(), "b", true, 1.0, None));
     }
 
-    let simulated_rate = analyzer.simulate_adjustment(&additive_epsilon_proposal(-0.1), &outcomes);
+    let simulated_rate =
+        analyzer.simulate_adjustment(&additive_epsilon_proposal(-0.1), &outcomes);
     assert!(
         (simulated_rate - 0.8).abs() < 1e-5,
         "Expected 0.8, got {simulated_rate}"

--- a/crates/heimlern-feedback/tests/simulation_strategy.rs
+++ b/crates/heimlern-feedback/tests/simulation_strategy.rs
@@ -64,8 +64,7 @@ fn simulation_handles_unknown_strategies() {
         })
         .collect();
 
-    let simulated_rate =
-        analyzer.simulate_adjustment(&additive_epsilon_proposal(-0.1), &outcomes);
+    let simulated_rate = analyzer.simulate_adjustment(&additive_epsilon_proposal(-0.1), &outcomes);
     assert!((simulated_rate - 0.5).abs() < 1e-5);
 }
 
@@ -89,8 +88,7 @@ fn simulation_handles_mixed_known_unknown() {
         outcomes.push(create_outcome(&i.to_string(), "b", true, 1.0, None));
     }
 
-    let simulated_rate =
-        analyzer.simulate_adjustment(&additive_epsilon_proposal(-0.1), &outcomes);
+    let simulated_rate = analyzer.simulate_adjustment(&additive_epsilon_proposal(-0.1), &outcomes);
     assert!(
         (simulated_rate - 0.8).abs() < 1e-5,
         "Expected 0.8, got {simulated_rate}"

--- a/crates/heimlern-feedback/tests/simulation_strategy.rs
+++ b/crates/heimlern-feedback/tests/simulation_strategy.rs
@@ -1,0 +1,93 @@
+use heimlern_feedback::{DecisionOutcome, DeltaValue, Evidence, FeedbackAnalyzer, OutcomeType, ProposalStatus, WeightAdjustmentProposal};
+use std::collections::HashMap;
+
+fn create_outcome(
+    decision_id: &str,
+    action: &str,
+    success: bool,
+    reward: f32,
+    strategy: Option<&str>,
+) -> DecisionOutcome {
+    let metadata = strategy.map(|s| {
+        serde_json::json!({
+            "why": [s]
+        })
+    });
+
+    DecisionOutcome {
+        decision_id: decision_id.to_string(),
+        ts: "2026-01-04T12:00:00Z".to_string(),
+        policy_id: Some("test-policy".to_string()),
+        action: Some(action.to_string()),
+        outcome: if success {
+            OutcomeType::Success
+        } else {
+            OutcomeType::Failure
+        },
+        success,
+        reward: Some(reward),
+        context: None,
+        metadata,
+    }
+}
+
+fn additive_epsilon_proposal(value: f32) -> WeightAdjustmentProposal {
+    let mut deltas = HashMap::new();
+    deltas.insert("epsilon".to_string(), DeltaValue::Additive { value });
+    WeightAdjustmentProposal {
+        version: "legacy-simulation".to_string(),
+        basis_policy: "test".to_string(),
+        ts: "2026-01-04T12:00:00Z".to_string(),
+        deltas,
+        confidence: 0.7,
+        evidence: Evidence::default(),
+        reasoning: None,
+        status: ProposalStatus::Proposed,
+    }
+}
+
+#[test]
+fn simulation_handles_unknown_strategies() {
+    let analyzer = FeedbackAnalyzer::default();
+    let outcomes: Vec<DecisionOutcome> = (0..10)
+        .map(|i| {
+            create_outcome(
+                &i.to_string(),
+                "action",
+                i % 2 == 0,
+                if i % 2 == 0 { 1.0 } else { 0.0 },
+                None,
+            )
+        })
+        .collect();
+
+    let simulated_rate = analyzer.simulate_adjustment(&additive_epsilon_proposal(-0.1), &outcomes);
+    assert!((simulated_rate - 0.5).abs() < 1e-5);
+}
+
+#[test]
+fn simulation_handles_mixed_known_unknown() {
+    let analyzer = FeedbackAnalyzer::default();
+    let mut outcomes = Vec::new();
+
+    for i in 0..10 {
+        let is_exploit = i % 2 == 0;
+        outcomes.push(create_outcome(
+            &i.to_string(),
+            "a",
+            is_exploit,
+            if is_exploit { 1.0 } else { 0.0 },
+            Some(if is_exploit { "exploit" } else { "explore ε" }),
+        ));
+    }
+
+    for i in 10..20 {
+        outcomes.push(create_outcome(&i.to_string(), "b", true, 1.0, None));
+    }
+
+    let simulated_rate = analyzer.simulate_adjustment(&additive_epsilon_proposal(-0.1), &outcomes);
+    assert!(
+        (simulated_rate - 0.8).abs() < 1e-5,
+        "Expected 0.8, got {simulated_rate}"
+    );
+}

--- a/scripts/ola_adapter.py
+++ b/scripts/ola_adapter.py
@@ -1,5 +1,13 @@
 #!/usr/bin/env python3
-"""Convert redacted Grabowski friction summaries into routing outcome records."""
+"""Convert redacted Grabowski friction summaries into routing outcome records.
+
+Boundary: this Python module is a CLI/probe compatibility surface. The adapter
+invariants for route-key construction, reward clamping and state normalization
+are represented with regression coverage in the Rust feedback core at
+``crates/heimlern-feedback/src/ola_adapter.rs``. Changes here must preserve that
+Rust-owned contract instead of making Python the only authority for the
+transformation rules.
+"""
 from __future__ import annotations
 
 import argparse


### PR DESCRIPTION
Bureau-Task: OPERATOR-LEARNING-AXIS-V1-T003

## Summary

Moves the safety-critical OLA adapter invariants into the tested Rust feedback core while keeping Python as a probe/CLI compatibility boundary.

Changes:
- add `crates/heimlern-feedback/src/ola_adapter.rs`
- cover route-key sanitizing, route delta key failure modes, reward clamping, state normalization, outcome classification and reward computation in Rust tests
- expose the module from `heimlern-feedback`
- add integration tests preserving strategy simulation coverage
- document `scripts/ola_adapter.py` as a probe/compatibility boundary, not the only authority for transformation rules

## Boundary

This does not change routing behavior and does not auto-apply learning output. It only moves adapter invariants into a typed/tested Rust surface and leaves Python as review/probe glue.

## Validation

GitHub Actions will run. Expected focused command is `cargo test -q -p heimlern-feedback`.