### PR TITLE
feat(core): move OLA adapter invariants into Rust

### DIFF
--- a/crates/heimlern-cli/src/bin/heimlern-ola.rs
+++ b/crates/heimlern-cli/src/bin/heimlern-ola.rs
@@ -8,7 +8,12 @@ use std::fs::File;
 use std::path::PathBuf;
 
 #[derive(Parser)]
-#[command(author, version, about = "Rust-owned OLA adapter normalization", long_about = None)]
+#[command(
+    author,
+    version,
+    about = "Rust-owned OLA adapter normalization",
+    long_about = None
+)]
 struct Cli {
     #[command(subcommand)]
     command: Commands,

--- a/crates/heimlern-cli/src/bin/heimlern-ola.rs
+++ b/crates/heimlern-cli/src/bin/heimlern-ola.rs
@@ -1,0 +1,101 @@
+//! CLI wrapper for Rust-owned Operator Learning Axis normalization.
+
+use anyhow::{Context, Result};
+use clap::{Parser, Subcommand, ValueEnum};
+use heimlern_core::ola;
+use serde_json::{json, Value};
+use std::fs::File;
+use std::path::PathBuf;
+
+#[derive(Parser)]
+#[command(author, version, about = "Rust-owned OLA adapter normalization", long_about = None)]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Convert a redacted Grabowski friction record into OLA outcome JSON.
+    Adapt {
+        /// Input JSON file containing one redacted friction/outcome record.
+        #[arg(long)]
+        input: PathBuf,
+        /// Output shape.
+        #[arg(long, value_enum, default_value_t = Emit::RoutingOutcome)]
+        emit: Emit,
+        /// Policy id to embed when emitting a decision outcome.
+        #[arg(long, default_value = ola::DEFAULT_POLICY_ID)]
+        policy_id: String,
+    },
+    /// Convert a routing outcome JSON record into decision-outcome JSON.
+    DecisionOutcome {
+        /// Input JSON file containing one routing outcome record.
+        #[arg(long)]
+        input: PathBuf,
+        /// Policy id to embed in the decision outcome.
+        #[arg(long, default_value = ola::DEFAULT_POLICY_ID)]
+        policy_id: String,
+    },
+    /// Derive the safe policy delta key for a route action.
+    RouteDeltaKey {
+        /// Action string, e.g. route.direct:patch.
+        action: String,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, ValueEnum)]
+enum Emit {
+    RoutingOutcome,
+    DecisionOutcome,
+}
+
+fn read_json(path: &PathBuf) -> Result<Value> {
+    let file = File::open(path).with_context(|| format!("failed to open {}", path.display()))?;
+    serde_json::from_reader(file).with_context(|| format!("failed to parse {}", path.display()))
+}
+
+fn print_json(value: &Value) -> Result<()> {
+    println!("{}", serde_json::to_string_pretty(value)?);
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+    match cli.command {
+        Commands::Adapt {
+            input,
+            emit,
+            policy_id,
+        } => {
+            let input_record = read_json(&input)?;
+            let routing_outcome = ola::adapt(&input_record);
+            let payload = if emit == Emit::DecisionOutcome {
+                ola::to_decision_outcome(&routing_outcome, &policy_id)
+            } else {
+                routing_outcome
+            };
+            print_json(&payload)?;
+        }
+        Commands::DecisionOutcome { input, policy_id } => {
+            let routing_outcome = read_json(&input)?;
+            let payload = ola::to_decision_outcome(&routing_outcome, &policy_id);
+            print_json(&payload)?;
+        }
+        Commands::RouteDeltaKey { action } => match ola::route_delta_key(&action) {
+            Ok(route_key) => print_json(&json!({
+                "delta_key": route_key.delta_key,
+                "route": route_key.route
+            }))?,
+            Err(err) => {
+                let payload = json!({
+                    "kind": err.kind().as_str(),
+                    "message": err.message()
+                });
+                eprintln!("{}", serde_json::to_string_pretty(&payload)?);
+                std::process::exit(2);
+            }
+        },
+    }
+    Ok(())
+}

--- a/crates/heimlern-cli/src/bin/heimlern-ola.rs
+++ b/crates/heimlern-cli/src/bin/heimlern-ola.rs
@@ -22,7 +22,7 @@ enum Commands {
         #[arg(long)]
         input: PathBuf,
         /// Output shape.
-        #[arg(long, value_enum, default_value_t = Emit::RoutingOutcome)]
+        #[arg(long, value_enum, default_value = "routing-outcome")]
         emit: Emit,
         /// Policy id to embed when emitting a decision outcome.
         #[arg(long, default_value = "grabowski-routing-v0")]

--- a/crates/heimlern-cli/src/bin/heimlern-ola.rs
+++ b/crates/heimlern-cli/src/bin/heimlern-ola.rs
@@ -25,7 +25,7 @@ enum Commands {
         #[arg(long, value_enum, default_value_t = Emit::RoutingOutcome)]
         emit: Emit,
         /// Policy id to embed when emitting a decision outcome.
-        #[arg(long, default_value = ola::DEFAULT_POLICY_ID)]
+        #[arg(long, default_value = "grabowski-routing-v0")]
         policy_id: String,
     },
     /// Convert a routing outcome JSON record into decision-outcome JSON.
@@ -34,7 +34,7 @@ enum Commands {
         #[arg(long)]
         input: PathBuf,
         /// Policy id to embed in the decision outcome.
-        #[arg(long, default_value = ola::DEFAULT_POLICY_ID)]
+        #[arg(long, default_value = "grabowski-routing-v0")]
         policy_id: String,
     },
     /// Derive the safe policy delta key for a route action.

--- a/crates/heimlern-core/src/lib.rs
+++ b/crates/heimlern-core/src/lib.rs
@@ -8,6 +8,7 @@
 //! APIs, Persistenzschichten oder Tests eingebettet werden können.
 
 pub mod event;
+pub mod ola;
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;

--- a/crates/heimlern-core/src/ola.rs
+++ b/crates/heimlern-core/src/ola.rs
@@ -10,9 +10,27 @@ use std::fmt;
 
 pub const OUTCOME_VERSION: &str = "operator.routing_outcome.v1";
 pub const DEFAULT_POLICY_ID: &str = "grabowski-routing-v0";
-pub const VALID_COMPLETION_STATES: &[&str] = &["completed", "blocked", "deferred", "failed", "unknown"];
-pub const VALID_CI_STATES: &[&str] = &["pass", "fail", "pending", "not_applicable", "unknown"];
-pub const VALID_PR_STATES: &[&str] = &["merged", "open", "closed", "not_applicable", "unknown"];
+pub const VALID_COMPLETION_STATES: &[&str] = &[
+    "completed",
+    "blocked",
+    "deferred",
+    "failed",
+    "unknown",
+];
+pub const VALID_CI_STATES: &[&str] = &[
+    "pass",
+    "fail",
+    "pending",
+    "not_applicable",
+    "unknown",
+];
+pub const VALID_PR_STATES: &[&str] = &[
+    "merged",
+    "open",
+    "closed",
+    "not_applicable",
+    "unknown",
+];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -74,7 +92,13 @@ pub fn is_allowed_delta_key_char(ch: char) -> bool {
 pub fn safe_route(value: &str) -> String {
     let mapped: String = value
         .chars()
-        .map(|ch| if is_allowed_delta_key_char(ch) { ch } else { '_' })
+        .map(|ch| {
+            if is_allowed_delta_key_char(ch) {
+                ch
+            } else {
+                '_'
+            }
+        })
         .collect();
     let trimmed = mapped.trim_matches(|ch| matches!(ch, '.' | '_' | '-'));
     if trimmed.is_empty() {
@@ -148,12 +172,18 @@ pub fn normalized_friction(raw_items: Option<&Value>) -> Vec<Value> {
     let mut output = Vec::new();
     for raw in items.iter().filter(|item| item.is_object()) {
         let mut item = Map::new();
-        item.insert("kind".to_string(), Value::String(string_field(raw, "kind", "unknown")));
+        item.insert(
+            "kind".to_string(),
+            Value::String(string_field(raw, "kind", "unknown")),
+        );
         item.insert(
             "surface".to_string(),
             Value::String(string_field(raw, "surface", "unknown")),
         );
-        item.insert("resolved".to_string(), Value::Bool(bool_from(raw.get("resolved"))));
+        item.insert(
+            "resolved".to_string(),
+            Value::Bool(bool_from(raw.get("resolved"))),
+        );
         if let Some(operation) = optional_limited_string(raw, "operation", 160) {
             item.insert("operation".to_string(), Value::String(operation));
         }
@@ -191,7 +221,6 @@ pub fn compute_reward(
         "blocked" => -0.35,
         "deferred" => -0.1,
         "failed" => -0.75,
-        "unknown" => 0.0,
         _ => 0.0,
     };
     reward -= friction_count.min(5) as f64 * 0.05;
@@ -212,7 +241,7 @@ pub fn compute_reward(
         "closed" => reward -= 0.1,
         _ => {}
     }
-    reward -= rework_count.max(0).min(5) as f64 * 0.05;
+    reward -= rework_count.clamp(0, 5) as f64 * 0.05;
     clamp_reward(reward)
 }
 
@@ -251,7 +280,10 @@ pub fn adapt(input_record: &Value) -> Value {
         .unwrap_or(0);
 
     let mut metrics = Map::new();
-    metrics.insert("completion_state".to_string(), Value::String(completion_state.clone()));
+    metrics.insert(
+        "completion_state".to_string(),
+        Value::String(completion_state.clone()),
+    );
     metrics.insert("friction_count".to_string(), json!(friction_count));
     metrics.insert(
         "blocked_by_platform_filter".to_string(),
@@ -302,10 +334,11 @@ pub fn adapt(input_record: &Value) -> Value {
 
 pub fn to_decision_outcome(routing_outcome: &Value, policy_id: &str) -> Value {
     let outcome = string_field(routing_outcome, "outcome", "unknown");
-    let mut success = outcome == "success";
-    if outcome == "partial" {
-        success = bool_from(routing_outcome.get("resolved"));
-    }
+    let success = match outcome.as_str() {
+        "success" => true,
+        "partial" => bool_from(routing_outcome.get("resolved")),
+        _ => false,
+    };
     let route_used = string_field(routing_outcome, "route_used", "unknown_route");
     json!({
         "decision_id": string_field(routing_outcome, "decision_id", "unknown-decision"),
@@ -323,7 +356,10 @@ pub fn to_decision_outcome(routing_outcome: &Value, policy_id: &str) -> Value {
             "source_version": routing_outcome.get("version").cloned().unwrap_or(Value::Null),
             "metrics": routing_outcome.get("metrics").cloned().unwrap_or_else(|| json!({})),
             "friction": routing_outcome.get("friction").cloned().unwrap_or_else(|| json!([])),
-            "does_not_establish": ["routing_policy_readiness", "automatic_rule_change_permission"]
+            "does_not_establish": [
+                "routing_policy_readiness",
+                "automatic_rule_change_permission"
+            ]
         }
     })
 }
@@ -331,6 +367,7 @@ pub fn to_decision_outcome(routing_outcome: &Value, policy_id: &str) -> Value {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
 
     #[test]
     fn safe_route_matches_legacy_cases() {
@@ -339,20 +376,35 @@ mod tests {
         assert_eq!(safe_route("direct/patch/v2"), "direct_patch_v2");
         assert_eq!(safe_route("direct_patch"), "direct_patch");
         assert_eq!(safe_route("foo__bar"), "foo__bar");
-        assert_eq!(safe_route("route.with.dots-and-dashes"), "route.with.dots-and-dashes");
+        assert_eq!(
+            safe_route("route.with.dots-and-dashes"),
+            "route.with.dots-and-dashes"
+        );
         assert_eq!(safe_route("röute"), "r_ute");
         assert_eq!(safe_route("中"), "unknown_route");
     }
 
     #[test]
     fn route_delta_key_fails_closed() {
+        let route_key = match route_delta_key("route.direct:patch") {
+            Ok(route_key) => route_key,
+            Err(err) => panic!("unexpected route key error: {err}"),
+        };
+        assert_eq!(route_key.delta_key, "route.direct_patch.weight");
+
+        let no_prefix = match route_delta_key("direct_patch") {
+            Ok(route_key) => panic!("unexpected route key: {route_key:?}"),
+            Err(err) => err,
+        };
         assert_eq!(
-            route_delta_key("route.direct:patch").expect("route key").delta_key,
-            "route.direct_patch.weight"
+            no_prefix.kind(),
+            RouteDeltaKeyErrorKind::RouteDeltaKeyInvalid
         );
-        let no_prefix = route_delta_key("direct_patch").expect_err("missing prefix must fail");
-        assert_eq!(no_prefix.kind(), RouteDeltaKeyErrorKind::RouteDeltaKeyInvalid);
-        let empty = route_delta_key("route.").expect_err("empty route must fail");
+
+        let empty = match route_delta_key("route.") {
+            Ok(route_key) => panic!("unexpected route key: {route_key:?}"),
+            Err(err) => err,
+        };
         assert_eq!(empty.kind(), RouteDeltaKeyErrorKind::RouteDeltaKeyInvalid);
     }
 
@@ -361,8 +413,14 @@ mod tests {
         assert_eq!(clamp_reward(2.5), 1.0);
         assert_eq!(clamp_reward(-2.5), -1.0);
         assert_eq!(clamp_reward(0.12349), 0.123);
-        assert_eq!(normalized_state(Some("completed"), VALID_COMPLETION_STATES, "unknown"), "completed");
-        assert_eq!(normalized_state(Some("bogus"), VALID_COMPLETION_STATES, "unknown"), "unknown");
+        assert_eq!(
+            normalized_state(Some("completed"), VALID_COMPLETION_STATES, "unknown"),
+            "completed"
+        );
+        assert_eq!(
+            normalized_state(Some("bogus"), VALID_COMPLETION_STATES, "unknown"),
+            "unknown"
+        );
         assert_eq!(normalized_state(None, VALID_COMPLETION_STATES, "unknown"), "unknown");
     }
 
@@ -410,6 +468,6 @@ mod tests {
         let decision = to_decision_outcome(&routing, DEFAULT_POLICY_ID);
         assert_eq!(decision["policy_id"], DEFAULT_POLICY_ID);
         assert_eq!(decision["action"], "route.direct:patch");
-        assert_eq!(decision["success"], true);
+        assert!(decision["success"].as_bool().unwrap_or_default());
     }
 }

--- a/crates/heimlern-core/src/ola.rs
+++ b/crates/heimlern-core/src/ola.rs
@@ -1,0 +1,415 @@
+//! Operator Learning Axis adapter invariants.
+//!
+//! This module is the Rust-owned contract for OLA adapter normalization. Python
+//! scripts may call into it as probes or wrappers, but route-key sanitizing,
+//! reward clamping and state normalization live here.
+
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Map, Value};
+use std::fmt;
+
+pub const OUTCOME_VERSION: &str = "operator.routing_outcome.v1";
+pub const DEFAULT_POLICY_ID: &str = "grabowski-routing-v0";
+pub const VALID_COMPLETION_STATES: &[&str] = &["completed", "blocked", "deferred", "failed", "unknown"];
+pub const VALID_CI_STATES: &[&str] = &["pass", "fail", "pending", "not_applicable", "unknown"];
+pub const VALID_PR_STATES: &[&str] = &["merged", "open", "closed", "not_applicable", "unknown"];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RouteDeltaKeyErrorKind {
+    RouteDeltaKeyInvalid,
+    RouteDeltaKeyCollision,
+}
+
+impl RouteDeltaKeyErrorKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::RouteDeltaKeyInvalid => "route_delta_key_invalid",
+            Self::RouteDeltaKeyCollision => "route_delta_key_collision",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RouteDeltaKeyError {
+    kind: RouteDeltaKeyErrorKind,
+    message: String,
+}
+
+impl RouteDeltaKeyError {
+    pub fn new(kind: RouteDeltaKeyErrorKind, message: impl Into<String>) -> Self {
+        Self {
+            kind,
+            message: message.into(),
+        }
+    }
+
+    pub fn kind(&self) -> RouteDeltaKeyErrorKind {
+        self.kind
+    }
+
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+}
+
+impl fmt::Display for RouteDeltaKeyError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}: {}", self.kind.as_str(), self.message)
+    }
+}
+
+impl std::error::Error for RouteDeltaKeyError {}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RouteDeltaKey {
+    pub delta_key: String,
+    pub route: String,
+}
+
+pub fn is_allowed_delta_key_char(ch: char) -> bool {
+    ch.is_ascii_alphanumeric() || matches!(ch, '.' | '_' | '-')
+}
+
+pub fn safe_route(value: &str) -> String {
+    let mapped: String = value
+        .chars()
+        .map(|ch| if is_allowed_delta_key_char(ch) { ch } else { '_' })
+        .collect();
+    let trimmed = mapped.trim_matches(|ch| matches!(ch, '.' | '_' | '-'));
+    if trimmed.is_empty() {
+        "unknown_route".to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+pub fn route_delta_key(action: &str) -> Result<RouteDeltaKey, RouteDeltaKeyError> {
+    let route = action.strip_prefix("route.").ok_or_else(|| {
+        RouteDeltaKeyError::new(
+            RouteDeltaKeyErrorKind::RouteDeltaKeyInvalid,
+            format!("route action must start with 'route.': {action:?}"),
+        )
+    })?;
+
+    if route.is_empty() {
+        return Err(RouteDeltaKeyError::new(
+            RouteDeltaKeyErrorKind::RouteDeltaKeyInvalid,
+            format!("route action has empty route: {action:?}"),
+        ));
+    }
+
+    Ok(RouteDeltaKey {
+        delta_key: format!("route.{}.weight", safe_route(route)),
+        route: route.to_string(),
+    })
+}
+
+pub fn clamp_reward(value: f64) -> f64 {
+    if !value.is_finite() {
+        return 0.0;
+    }
+    ((value.clamp(-1.0, 1.0) * 1000.0).round()) / 1000.0
+}
+
+pub fn normalized_state(value: Option<&str>, allowed: &[&str], fallback: &str) -> String {
+    match value {
+        Some(candidate) if allowed.contains(&candidate) => candidate.to_string(),
+        _ => fallback.to_string(),
+    }
+}
+
+pub fn bool_from(value: Option<&Value>) -> bool {
+    matches!(value, Some(Value::Bool(true)))
+}
+
+fn string_field(input: &Value, key: &str, fallback: &str) -> String {
+    input
+        .get(key)
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(fallback)
+        .to_string()
+}
+
+fn optional_limited_string(input: &Value, key: &str, max_chars: usize) -> Option<String> {
+    input
+        .get(key)
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .map(|value| value.chars().take(max_chars).collect())
+}
+
+pub fn normalized_friction(raw_items: Option<&Value>) -> Vec<Value> {
+    let Some(items) = raw_items.and_then(Value::as_array) else {
+        return Vec::new();
+    };
+
+    let mut output = Vec::new();
+    for raw in items.iter().filter(|item| item.is_object()) {
+        let mut item = Map::new();
+        item.insert("kind".to_string(), Value::String(string_field(raw, "kind", "unknown")));
+        item.insert(
+            "surface".to_string(),
+            Value::String(string_field(raw, "surface", "unknown")),
+        );
+        item.insert("resolved".to_string(), Value::Bool(bool_from(raw.get("resolved"))));
+        if let Some(operation) = optional_limited_string(raw, "operation", 160) {
+            item.insert("operation".to_string(), Value::String(operation));
+        }
+        if let Some(fallback) = optional_limited_string(raw, "fallback", 500) {
+            item.insert("fallback".to_string(), Value::String(fallback));
+        }
+        output.push(Value::Object(item));
+    }
+    output
+}
+
+pub fn classify_outcome(completion_state: &str, unresolved_friction: usize) -> String {
+    match completion_state {
+        "completed" => "success".to_string(),
+        "failed" => "failure".to_string(),
+        "blocked" | "deferred" => "partial".to_string(),
+        _ if unresolved_friction > 0 => "partial".to_string(),
+        _ => "unknown".to_string(),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn compute_reward(
+    completion_state: &str,
+    friction_count: usize,
+    unresolved_friction: usize,
+    blocked_by_platform_filter: bool,
+    manual_operator_needed: bool,
+    ci_state: &str,
+    pr_state: &str,
+    rework_count: i64,
+) -> f64 {
+    let mut reward = match completion_state {
+        "completed" => 0.7,
+        "blocked" => -0.35,
+        "deferred" => -0.1,
+        "failed" => -0.75,
+        "unknown" => 0.0,
+        _ => 0.0,
+    };
+    reward -= friction_count.min(5) as f64 * 0.05;
+    reward -= unresolved_friction.min(5) as f64 * 0.1;
+    if blocked_by_platform_filter {
+        reward -= 0.1;
+    }
+    if manual_operator_needed {
+        reward -= 0.15;
+    }
+    match ci_state {
+        "pass" => reward += 0.1,
+        "fail" => reward -= 0.2,
+        _ => {}
+    }
+    match pr_state {
+        "merged" => reward += 0.1,
+        "closed" => reward -= 0.1,
+        _ => {}
+    }
+    reward -= rework_count.max(0).min(5) as f64 * 0.05;
+    clamp_reward(reward)
+}
+
+pub fn adapt(input_record: &Value) -> Value {
+    let friction = normalized_friction(input_record.get("friction"));
+    let friction_count = friction.len();
+    let unresolved_friction = friction
+        .iter()
+        .filter(|item| item.get("resolved") != Some(&Value::Bool(true)))
+        .count();
+    let completion_state = normalized_state(
+        input_record.get("completion_state").and_then(Value::as_str),
+        VALID_COMPLETION_STATES,
+        "unknown",
+    );
+    let ci_state = normalized_state(
+        input_record.get("ci_state").and_then(Value::as_str),
+        VALID_CI_STATES,
+        "unknown",
+    );
+    let pr_state = normalized_state(
+        input_record.get("pr_state").and_then(Value::as_str),
+        VALID_PR_STATES,
+        "unknown",
+    );
+    let blocked_by_platform_filter = friction
+        .iter()
+        .any(|item| item.get("kind").and_then(Value::as_str) == Some("platform_filter"));
+    let manual_operator_needed = bool_from(input_record.get("manual_operator_needed"))
+        || friction
+            .iter()
+            .any(|item| item.get("kind").and_then(Value::as_str) == Some("user_input"));
+    let rework_count = input_record
+        .get("rework_count")
+        .and_then(Value::as_i64)
+        .unwrap_or(0);
+
+    let mut metrics = Map::new();
+    metrics.insert("completion_state".to_string(), Value::String(completion_state.clone()));
+    metrics.insert("friction_count".to_string(), json!(friction_count));
+    metrics.insert(
+        "blocked_by_platform_filter".to_string(),
+        Value::Bool(blocked_by_platform_filter),
+    );
+    metrics.insert(
+        "manual_operator_needed".to_string(),
+        Value::Bool(manual_operator_needed),
+    );
+    metrics.insert("ci_state".to_string(), Value::String(ci_state.clone()));
+    metrics.insert("pr_state".to_string(), Value::String(pr_state.clone()));
+    metrics.insert("rework_count".to_string(), json!(rework_count));
+
+    if let Some(elapsed) = input_record.get("elapsed_seconds").and_then(Value::as_i64) {
+        if elapsed >= 0 {
+            metrics.insert("elapsed_seconds".to_string(), json!(elapsed));
+        }
+    }
+
+    let outcome = classify_outcome(&completion_state, unresolved_friction);
+    json!({
+        "version": OUTCOME_VERSION,
+        "decision_id": string_field(input_record, "decision_id", "unknown-decision"),
+        "ts": string_field(input_record, "ts", "unknown-ts"),
+        "task_class": string_field(input_record, "task_class", "unknown_task"),
+        "route_used": string_field(input_record, "route_used", "unknown_route"),
+        "outcome": outcome,
+        "resolved": completion_state == "completed" && unresolved_friction == 0,
+        "reward": compute_reward(
+            &completion_state,
+            friction_count,
+            unresolved_friction,
+            blocked_by_platform_filter,
+            manual_operator_needed,
+            &ci_state,
+            &pr_state,
+            rework_count,
+        ),
+        "metrics": Value::Object(metrics),
+        "friction": friction,
+        "does_not_establish": [
+            "causal_route_superiority",
+            "routing_policy_readiness",
+            "auto_apply_permission"
+        ]
+    })
+}
+
+pub fn to_decision_outcome(routing_outcome: &Value, policy_id: &str) -> Value {
+    let outcome = string_field(routing_outcome, "outcome", "unknown");
+    let mut success = outcome == "success";
+    if outcome == "partial" {
+        success = bool_from(routing_outcome.get("resolved"));
+    }
+    let route_used = string_field(routing_outcome, "route_used", "unknown_route");
+    json!({
+        "decision_id": string_field(routing_outcome, "decision_id", "unknown-decision"),
+        "ts": string_field(routing_outcome, "ts", "unknown-ts"),
+        "policy_id": policy_id,
+        "action": format!("route.{route_used}"),
+        "outcome": outcome,
+        "success": success,
+        "reward": routing_outcome.get("reward").cloned().unwrap_or(Value::Null),
+        "context": {
+            "task_class": routing_outcome.get("task_class").cloned().unwrap_or(Value::Null),
+            "route_used": route_used
+        },
+        "metadata": {
+            "source_version": routing_outcome.get("version").cloned().unwrap_or(Value::Null),
+            "metrics": routing_outcome.get("metrics").cloned().unwrap_or_else(|| json!({})),
+            "friction": routing_outcome.get("friction").cloned().unwrap_or_else(|| json!([])),
+            "does_not_establish": ["routing_policy_readiness", "automatic_rule_change_permission"]
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn safe_route_matches_legacy_cases() {
+        assert_eq!(safe_route(""), "unknown_route");
+        assert_eq!(safe_route("direct:patch"), "direct_patch");
+        assert_eq!(safe_route("direct/patch/v2"), "direct_patch_v2");
+        assert_eq!(safe_route("direct_patch"), "direct_patch");
+        assert_eq!(safe_route("foo__bar"), "foo__bar");
+        assert_eq!(safe_route("route.with.dots-and-dashes"), "route.with.dots-and-dashes");
+        assert_eq!(safe_route("röute"), "r_ute");
+        assert_eq!(safe_route("中"), "unknown_route");
+    }
+
+    #[test]
+    fn route_delta_key_fails_closed() {
+        assert_eq!(
+            route_delta_key("route.direct:patch").expect("route key").delta_key,
+            "route.direct_patch.weight"
+        );
+        let no_prefix = route_delta_key("direct_patch").expect_err("missing prefix must fail");
+        assert_eq!(no_prefix.kind(), RouteDeltaKeyErrorKind::RouteDeltaKeyInvalid);
+        let empty = route_delta_key("route.").expect_err("empty route must fail");
+        assert_eq!(empty.kind(), RouteDeltaKeyErrorKind::RouteDeltaKeyInvalid);
+    }
+
+    #[test]
+    fn reward_clamping_and_state_normalization_are_core_contracts() {
+        assert_eq!(clamp_reward(2.5), 1.0);
+        assert_eq!(clamp_reward(-2.5), -1.0);
+        assert_eq!(clamp_reward(0.12349), 0.123);
+        assert_eq!(normalized_state(Some("completed"), VALID_COMPLETION_STATES, "unknown"), "completed");
+        assert_eq!(normalized_state(Some("bogus"), VALID_COMPLETION_STATES, "unknown"), "unknown");
+        assert_eq!(normalized_state(None, VALID_COMPLETION_STATES, "unknown"), "unknown");
+    }
+
+    #[test]
+    fn adapt_normalizes_routing_outcome() {
+        let input = json!({
+            "decision_id": "gr-example-001",
+            "ts": "2026-07-08T18:00:00Z",
+            "task_class": "contract_slice",
+            "route_used": "typed_tool",
+            "completion_state": "blocked",
+            "ci_state": "unknown",
+            "pr_state": "open",
+            "friction": [{
+                "kind": "platform_filter",
+                "surface": "chat_tool",
+                "operation": "bounded_write",
+                "resolved": false,
+                "fallback": "narrowed scope and stopped before mutation"
+            }]
+        });
+
+        let outcome = adapt(&input);
+        assert_eq!(outcome["version"], OUTCOME_VERSION);
+        assert_eq!(outcome["outcome"], "partial");
+        assert_eq!(outcome["metrics"]["friction_count"], 1);
+        assert_eq!(outcome["metrics"]["blocked_by_platform_filter"], true);
+        assert_eq!(outcome["reward"].as_f64().unwrap_or_default(), -0.6);
+    }
+
+    #[test]
+    fn decision_outcome_uses_rust_normalized_route_context() {
+        let routing = json!({
+            "version": OUTCOME_VERSION,
+            "decision_id": "gr-example-001",
+            "ts": "2026-07-08T18:00:00Z",
+            "task_class": "contract_slice",
+            "route_used": "direct:patch",
+            "outcome": "success",
+            "resolved": true,
+            "reward": 0.8,
+            "metrics": {},
+            "friction": []
+        });
+        let decision = to_decision_outcome(&routing, DEFAULT_POLICY_ID);
+        assert_eq!(decision["policy_id"], DEFAULT_POLICY_ID);
+        assert_eq!(decision["action"], "route.direct:patch");
+        assert_eq!(decision["success"], true);
+    }
+}

--- a/crates/heimlern-core/src/ola.rs
+++ b/crates/heimlern-core/src/ola.rs
@@ -10,27 +10,10 @@ use std::fmt;
 
 pub const OUTCOME_VERSION: &str = "operator.routing_outcome.v1";
 pub const DEFAULT_POLICY_ID: &str = "grabowski-routing-v0";
-pub const VALID_COMPLETION_STATES: &[&str] = &[
-    "completed",
-    "blocked",
-    "deferred",
-    "failed",
-    "unknown",
-];
-pub const VALID_CI_STATES: &[&str] = &[
-    "pass",
-    "fail",
-    "pending",
-    "not_applicable",
-    "unknown",
-];
-pub const VALID_PR_STATES: &[&str] = &[
-    "merged",
-    "open",
-    "closed",
-    "not_applicable",
-    "unknown",
-];
+pub const VALID_COMPLETION_STATES: &[&str] =
+    &["completed", "blocked", "deferred", "failed", "unknown"];
+pub const VALID_CI_STATES: &[&str] = &["pass", "fail", "pending", "not_applicable", "unknown"];
+pub const VALID_PR_STATES: &[&str] = &["merged", "open", "closed", "not_applicable", "unknown"];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -421,7 +404,10 @@ mod tests {
             normalized_state(Some("bogus"), VALID_COMPLETION_STATES, "unknown"),
             "unknown"
         );
-        assert_eq!(normalized_state(None, VALID_COMPLETION_STATES, "unknown"), "unknown");
+        assert_eq!(
+            normalized_state(None, VALID_COMPLETION_STATES, "unknown"),
+            "unknown"
+        );
     }
 
     #[test]

--- a/scripts/ola_adapter.py
+++ b/scripts/ola_adapter.py
@@ -1,191 +1,125 @@
 #!/usr/bin/env python3
-"""Convert redacted Grabowski friction summaries into routing outcome records."""
+"""Python wrapper for Rust-owned OLA routing outcome normalization.
+
+The transformation contract lives in `heimlern_core::ola` and the
+`heimlern-ola` CLI. This script remains as a compatibility wrapper for probes
+and fixtures.
+"""
 from __future__ import annotations
 
 import argparse
 import json
+import subprocess
+import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
 OUTCOME_VERSION = "operator.routing_outcome.v1"
 DEFAULT_POLICY_ID = "grabowski-routing-v0"
-VALID_COMPLETION_STATES = {"completed", "blocked", "deferred", "failed", "unknown"}
-VALID_CI_STATES = {"pass", "fail", "pending", "not_applicable", "unknown"}
-VALID_PR_STATES = {"merged", "open", "closed", "not_applicable", "unknown"}
+_ROUTE_DELTA_KEY_INVALID = "route_delta_key_invalid"
+_ROUTE_DELTA_KEY_COLLISION = "route_delta_key_collision"
+_ROUTE_DELTA_KEY_ERROR_KINDS = frozenset({_ROUTE_DELTA_KEY_INVALID, _ROUTE_DELTA_KEY_COLLISION})
+
+
+class RouteDeltaKeyError(ValueError):
+    """Raised when Rust rejects a routing action to delta-key mapping."""
+
+    def __init__(self, kind: str, message: str) -> None:
+        if kind not in _ROUTE_DELTA_KEY_ERROR_KINDS:
+            raise ValueError(f"unknown route delta key error kind: {kind!r}")
+        super().__init__(message)
+        self.kind = kind
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
 
 
 def iso_now() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
-def clamp_reward(value: float) -> float:
-    return max(-1.0, min(1.0, round(value, 3)))
+def _json_from_text(text: str) -> dict[str, Any]:
+    start = text.find("{")
+    if start == -1:
+        raise ValueError(f"no JSON object in command output: {text!r}")
+    return json.loads(text[start:])
 
 
-def normalized_state(value: Any, allowed: set[str], fallback: str = "unknown") -> str:
-    if isinstance(value, str) and value in allowed:
-        return value
-    return fallback
+def _run_ola(args: list[str]) -> dict[str, Any]:
+    cmd = ["cargo", "run", "-q", "-p", "heimlern-cli", "--bin", "heimlern-ola", "--", *args]
+    result = subprocess.run(
+        cmd,
+        cwd=repo_root(),
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or result.stdout.strip() or f"heimlern-ola exited {result.returncode}")
+    return _json_from_text(result.stdout)
 
 
-def bool_from(value: Any) -> bool:
-    return bool(value) if isinstance(value, bool) else False
-
-
-def normalized_friction(raw_items: Any) -> list[dict[str, Any]]:
-    if not isinstance(raw_items, list):
-        return []
-    items: list[dict[str, Any]] = []
-    for raw in raw_items:
-        if not isinstance(raw, dict):
-            continue
-        item = {
-            "kind": str(raw.get("kind") or "unknown"),
-            "surface": str(raw.get("surface") or "unknown"),
-            "resolved": bool_from(raw.get("resolved")),
-        }
-        operation = raw.get("operation")
-        if isinstance(operation, str) and operation:
-            item["operation"] = operation[:160]
-        fallback = raw.get("fallback")
-        if isinstance(fallback, str) and fallback:
-            item["fallback"] = fallback[:500]
-        items.append(item)
-    return items
-
-
-def classify_outcome(completion_state: str, unresolved_friction: int) -> str:
-    if completion_state == "completed":
-        return "success"
-    if completion_state == "failed":
-        return "failure"
-    if completion_state in {"blocked", "deferred"}:
-        return "partial"
-    if unresolved_friction > 0:
-        return "partial"
-    return "unknown"
-
-
-def compute_reward(
-    completion_state: str,
-    friction_count: int,
-    unresolved_friction: int,
-    blocked_by_platform_filter: bool,
-    manual_operator_needed: bool,
-    ci_state: str,
-    pr_state: str,
-    rework_count: int,
-) -> float:
-    reward = {
-        "completed": 0.7,
-        "blocked": -0.35,
-        "deferred": -0.1,
-        "failed": -0.75,
-        "unknown": 0.0,
-    }.get(completion_state, 0.0)
-    reward -= min(friction_count, 5) * 0.05
-    reward -= min(unresolved_friction, 5) * 0.1
-    if blocked_by_platform_filter:
-        reward -= 0.1
-    if manual_operator_needed:
-        reward -= 0.15
-    if ci_state == "pass":
-        reward += 0.1
-    elif ci_state == "fail":
-        reward -= 0.2
-    if pr_state == "merged":
-        reward += 0.1
-    elif pr_state == "closed":
-        reward -= 0.1
-    reward -= min(max(rework_count, 0), 5) * 0.05
-    return clamp_reward(reward)
+def _with_temp_json(payload: dict[str, Any], args: list[str]) -> dict[str, Any]:
+    with tempfile.NamedTemporaryFile("w", suffix=".json", encoding="utf-8", delete=True) as tmp:
+        json.dump(payload, tmp, ensure_ascii=False)
+        tmp.flush()
+        return _run_ola([*args, "--input", tmp.name])
 
 
 def adapt(input_record: dict[str, Any]) -> dict[str, Any]:
-    friction = normalized_friction(input_record.get("friction"))
-    friction_count = len(friction)
-    unresolved_friction = sum(1 for item in friction if not item.get("resolved"))
-    completion_state = normalized_state(
-        input_record.get("completion_state"), VALID_COMPLETION_STATES
-    )
-    ci_state = normalized_state(input_record.get("ci_state"), VALID_CI_STATES, "unknown")
-    pr_state = normalized_state(input_record.get("pr_state"), VALID_PR_STATES, "unknown")
-    blocked_by_platform_filter = any(
-        item.get("kind") == "platform_filter" for item in friction
-    )
-    manual_operator_needed = bool_from(input_record.get("manual_operator_needed")) or any(
-        item.get("kind") == "user_input" for item in friction
-    )
-    rework_count = int(input_record.get("rework_count") or 0)
-    metrics = {
-        "completion_state": completion_state,
-        "friction_count": friction_count,
-        "blocked_by_platform_filter": blocked_by_platform_filter,
-        "manual_operator_needed": manual_operator_needed,
-        "ci_state": ci_state,
-        "pr_state": pr_state,
-        "rework_count": rework_count,
-    }
-    elapsed = input_record.get("elapsed_seconds")
-    if isinstance(elapsed, int) and elapsed >= 0:
-        metrics["elapsed_seconds"] = elapsed
-    outcome = classify_outcome(completion_state, unresolved_friction)
-    return {
-        "version": OUTCOME_VERSION,
-        "decision_id": str(input_record.get("decision_id") or "unknown-decision"),
-        "ts": str(input_record.get("ts") or iso_now()),
-        "task_class": str(input_record.get("task_class") or "unknown_task"),
-        "route_used": str(input_record.get("route_used") or "unknown_route"),
-        "outcome": outcome,
-        "resolved": completion_state == "completed" and unresolved_friction == 0,
-        "reward": compute_reward(
-            completion_state,
-            friction_count,
-            unresolved_friction,
-            blocked_by_platform_filter,
-            manual_operator_needed,
-            ci_state,
-            pr_state,
-            rework_count,
-        ),
-        "metrics": metrics,
-        "friction": friction,
-        "does_not_establish": [
-            "causal_route_superiority",
-            "routing_policy_readiness",
-            "auto_apply_permission",
-        ],
-    }
+    return _with_temp_json(input_record, ["adapt"])
 
 
 def to_decision_outcome(routing_outcome: dict[str, Any], policy_id: str = DEFAULT_POLICY_ID) -> dict[str, Any]:
-    outcome = str(routing_outcome.get("outcome") or "unknown")
-    success = outcome == "success"
-    if outcome == "partial":
-        success = bool_from(routing_outcome.get("resolved"))
-    route_used = str(routing_outcome.get("route_used") or "unknown_route")
-    return {
-        "decision_id": str(routing_outcome.get("decision_id") or "unknown-decision"),
-        "ts": str(routing_outcome.get("ts") or iso_now()),
-        "policy_id": policy_id,
-        "action": f"route.{route_used}",
-        "outcome": outcome,
-        "success": success,
-        "reward": routing_outcome.get("reward"),
-        "context": {"task_class": routing_outcome.get("task_class"), "route_used": route_used},
-        "metadata": {
-            "source_version": routing_outcome.get("version"),
-            "metrics": routing_outcome.get("metrics", {}),
-            "friction": routing_outcome.get("friction", []),
-            "does_not_establish": ["routing_policy_readiness", "automatic_rule_change_permission"],
-        },
-    }
+    return _with_temp_json(routing_outcome, ["decision-outcome", "--policy-id", policy_id])
+
+
+def route_delta_key(action: str) -> tuple[str, str]:
+    cmd = [
+        "cargo",
+        "run",
+        "-q",
+        "-p",
+        "heimlern-cli",
+        "--bin",
+        "heimlern-ola",
+        "--",
+        "route-delta-key",
+        action,
+    ]
+    result = subprocess.run(
+        cmd,
+        cwd=repo_root(),
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if result.returncode != 0:
+        try:
+            payload = _json_from_text(result.stderr)
+            kind = str(payload.get("kind") or _ROUTE_DELTA_KEY_INVALID)
+            message = str(payload.get("message") or result.stderr.strip())
+        except Exception:
+            kind = _ROUTE_DELTA_KEY_INVALID
+            message = result.stderr.strip() or result.stdout.strip() or f"heimlern-ola exited {result.returncode}"
+        raise RouteDeltaKeyError(kind, message)
+    payload = _json_from_text(result.stdout)
+    return str(payload["delta_key"]), str(payload["route"])
 
 
 def run_self_test() -> None:
+    subprocess.run(
+        ["cargo", "test", "-q", "-p", "heimlern-core", "ola::"],
+        cwd=repo_root(),
+        check=True,
+    )
     sample = {
         "decision_id": "gr-example-001",
+        "ts": "2026-07-08T18:00:00Z",
         "task_class": "contract_slice",
         "route_used": "typed_tool",
         "completion_state": "blocked",
@@ -206,6 +140,7 @@ def run_self_test() -> None:
     assert outcome["metrics"]["friction_count"] == 1
     assert outcome["metrics"]["blocked_by_platform_filter"] is True
     assert outcome["reward"] < 0.0
+    assert route_delta_key("route.direct:patch") == ("route.direct_patch.weight", "direct:patch")
 
 
 def main() -> int:
@@ -217,13 +152,14 @@ def main() -> int:
     args = parser.parse_args()
     if args.self_test:
         run_self_test()
-        print("ola-adapter self-test ok")
+        print("ola-adapter wrapper self-test ok")
         return 0
     if not args.input:
         parser.error("input path required unless --self-test is used")
-    input_record = json.loads(Path(args.input).read_text(encoding="utf-8"))
-    routing_outcome = adapt(input_record)
-    payload = to_decision_outcome(routing_outcome, args.policy_id) if args.emit == "decision-outcome" else routing_outcome
+    if args.emit == "decision-outcome":
+        payload = _run_ola(["adapt", "--emit", "decision-outcome", "--policy-id", args.policy_id, "--input", args.input])
+    else:
+        payload = _run_ola(["adapt", "--emit", "routing-outcome", "--input", args.input])
     print(json.dumps(payload, indent=2, ensure_ascii=False))
     return 0
 

--- a/scripts/ola_probe.py
+++ b/scripts/ola_probe.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
-"""Probe OPLEARN routing outcomes before any routing proposal is allowed."""
+"""Probe OPLEARN routing outcomes before any routing proposal is allowed.
+
+Normalization and route-key derivation are delegated to Rust via ola_adapter.py.
+This script remains an analyzer/proposal probe; it does not own adapter invariants.
+"""
 from __future__ import annotations
 
 import argparse
@@ -8,30 +12,25 @@ from collections import defaultdict
 from pathlib import Path
 from typing import Any
 
-from ola_adapter import DEFAULT_POLICY_ID, adapt, iso_now, to_decision_outcome
+from ola_adapter import (
+    DEFAULT_POLICY_ID,
+    RouteDeltaKeyError,
+    adapt,
+    iso_now,
+    route_delta_key,
+    to_decision_outcome,
+)
 
 DEFAULT_MIN_DECISIONS = 10
 DEFAULT_MIN_ACTION_COUNT = 3
 DEFAULT_FAILURE_THRESHOLD = 0.6
-_ALLOWED_DELTA_KEY_CHARS = frozenset("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789._-")
 _ROUTE_DELTA_KEY_INVALID = "route_delta_key_invalid"
 _ROUTE_DELTA_KEY_COLLISION = "route_delta_key_collision"
-_ROUTE_DELTA_KEY_ERROR_KINDS = frozenset({_ROUTE_DELTA_KEY_INVALID, _ROUTE_DELTA_KEY_COLLISION})
 _DOES_NOT_ESTABLISH = (
     "routing_policy_readiness",
     "automatic_rule_change_permission",
     "sample_representativeness",
 )
-
-
-class RouteDeltaKeyError(ValueError):
-    """Raised when a routing action cannot be mapped to a safe delta key."""
-
-    def __init__(self, kind: str, message: str) -> None:
-        if kind not in _ROUTE_DELTA_KEY_ERROR_KINDS:
-            raise ValueError(f"unknown route delta key error kind: {kind!r}")
-        super().__init__(message)
-        self.kind = kind
 
 
 def ratio(num: int, den: int) -> float:
@@ -96,23 +95,6 @@ def summarize(decision_outcomes: list[dict[str, Any]]) -> dict[str, Any]:
         "by_action": finalize(by_action),
         "by_task_class": finalize(by_task_class),
     }
-
-
-def safe_route(value: str) -> str:
-    out = []
-    for ch in value:
-        out.append(ch if ch in _ALLOWED_DELTA_KEY_CHARS else "_")
-    result = "".join(out).strip("._-")
-    return result or "unknown_route"
-
-
-def route_delta_key(action: str) -> tuple[str, str]:
-    if not action.startswith("route."):
-        raise RouteDeltaKeyError(_ROUTE_DELTA_KEY_INVALID, f"route action must start with 'route.': {action!r}")
-    route = action.removeprefix("route.")
-    if route == "":
-        raise RouteDeltaKeyError(_ROUTE_DELTA_KEY_INVALID, f"route action has empty route: {action!r}")
-    return f"route.{safe_route(route)}.weight", route
 
 
 def maybe_propose(summary: dict[str, Any], min_decisions: int, min_action_count: int, failure_threshold: float) -> dict[str, Any] | None:
@@ -188,14 +170,6 @@ def probe(inputs: list[dict[str, Any]], min_decisions: int = DEFAULT_MIN_DECISIO
 
 
 def run_self_test() -> None:
-    assert safe_route("") == "unknown_route"
-    assert safe_route("direct:patch") == "direct_patch"
-    assert safe_route("direct/patch/v2") == "direct_patch_v2"
-    assert safe_route("direct_patch") == "direct_patch"
-    assert safe_route("foo__bar") == "foo__bar"
-    assert safe_route("route.with.dots-and-dashes") == "route.with.dots-and-dashes"
-    assert safe_route("röute") == "r_ute"
-    assert safe_route("中") == "unknown_route"
     assert route_delta_key("route.direct:patch") == ("route.direct_patch.weight", "direct:patch")
     assert route_delta_key("route.foo__bar") == ("route.foo__bar.weight", "foo__bar")
     assert route_delta_key("route.röute") == ("route.r_ute.weight", "röute")
@@ -227,7 +201,6 @@ def run_self_test() -> None:
     assert set(proposed["proposal"]["deltas"]) == {"route.direct_patch.weight"}
     assert all(delta["kind"] != "additive" for delta in proposed["proposal"]["deltas"].values())
     assert all(delta["kind"] == "relative" for delta in proposed["proposal"]["deltas"].values())
-    assert all(set(key) <= _ALLOWED_DELTA_KEY_CHARS for key in proposed["proposal"]["deltas"])
     assert proposed["proposal"]["version"] == "v1"
     assert proposed["proposal"]["confidence"] >= 0.5
     assert proposed["proposal"]["evidence"]["decisions_analyzed"] == 10


### PR DESCRIPTION
Bureau-Task: OPERATOR-LEARNING-AXIS-V1-T003

## Summary

Implements `OPERATOR-LEARNING-AXIS-V1-T003`.

- Adds `heimlern_core::ola` as the Rust-owned normalization contract for:
  - route delta-key sanitizing and fail-closed errors
  - reward clamping
  - completion/CI/PR state normalization
  - routing-outcome and decision-outcome conversion
- Adds `heimlern-ola` CLI wrapper under `heimlern-cli`.
- Refactors `scripts/ola_adapter.py` into a compatibility wrapper that delegates to Rust.
- Refactors `scripts/ola_probe.py` so the analyzer/proposal path calls the Rust route-key contract instead of owning sanitizing locally.

## Acceptance mapping

- `rust-invariants`: covered by `crates/heimlern-core/src/ola.rs` unit tests.
- `python-degraded`: Python adapter/probe now delegates normalization and route-key derivation to `heimlern-ola` / `heimlern_core::ola`.

## Validation

```text
python3 -m py_compile scripts/ola_adapter.py scripts/ola_probe.py scripts/validate_weight_adjustment_coherence.py
cargo test -q -p heimlern-core ola::
cargo test -q -p heimlern-cli --bin heimlern-ola
cargo test -q -p heimlern-feedback
python3 scripts/ola_adapter.py --self-test
python3 scripts/ola_probe.py --self-test
python3 scripts/validate_weight_adjustment_coherence.py --schema /tmp/heimlern-policy.weight_adjustment.v1.schema.json
git diff --check origin/main...HEAD
```

GitHub Actions are green for this PR.

## Safety boundary

This PR only creates proposal/analyzer normalization surfaces. It does not apply routing-policy changes automatically and does not mutate runtime policy state.
