### PR TITLE
feat: gate Heimlern proposals by consumer and expiry

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -45,12 +45,16 @@ jobs:
         with:
           python-version: '3.x'
       - name: Install jsonschema
-        run: python -m pip install --upgrade pip jsonschema
+        run: python -m pip install --upgrade pip jsonschema pytest
       - name: Validate sample JSONs
         run: |
           python scripts/validate_json.py \
           --schemas contracts/ \
           --samples data/samples/
+      - name: Validate active proposal registrations
+        run: python scripts/validate_proposal_registrations.py
+      - name: Test proposal registration gate
+        run: python -m pytest -q tests/test_proposal_registrations.py
       - name: Reject invalid feedback fixture
         run: |
           if python scripts/validate_json.py contracts/policy.feedback.schema.json data/samples/policy.feedback.rejected.json; then

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This correction supersedes older wording that frames heimlern mainly as a househ
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
 Siehe auch: **Policy-Lifecycle**: `docs/policy-lifecycle.md` und **Contracts** in `contracts/`.
+Neue Lern- und Policy-Vorschläge müssen zusätzlich als [consumer-bound proposal registration](proposals/README.md) angelegt werden. Ohne Consumer, Entscheidungsziel, Messkriterium, Ablaufdatum und proposal-only Boundary schlägt CI fehl.
 
 `heimlern` ist ein retrospektiver Lern- und Policy-Adaptionsmotor für den Heimgewebe-Organismus. Das Repository hält Rust-Kerne, Feedback-Analyse und auditable Vorschlagsformate bereit, damit Outcomes aus Chronik, Metriken und explizitem Feedback zu nachvollziehbaren Anpassungsvorschlägen werden.
 

--- a/contracts/learning.proposal.registration.v1.schema.json
+++ b/contracts/learning.proposal.registration.v1.schema.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://heimgewebe.local/heimlern/learning.proposal.registration.v1.schema.json",
+  "title": "Heimlern Learning Proposal Registration v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "proposal_id",
+    "consumer",
+    "decision_target",
+    "success_metric",
+    "expires_at",
+    "closure",
+    "boundary"
+  ],
+  "properties": {
+    "schema_version": {"const": "learning.proposal.registration.v1"},
+    "proposal_id": {"type": "string", "pattern": "^[a-z0-9][a-z0-9._-]{2,127}$"},
+    "consumer": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["organ", "use"],
+      "properties": {
+        "organ": {"type": "string", "minLength": 1},
+        "use": {"type": "string", "minLength": 10}
+      }
+    },
+    "decision_target": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["question", "owner"],
+      "properties": {
+        "question": {"type": "string", "minLength": 10},
+        "owner": {"type": "string", "minLength": 1}
+      }
+    },
+    "success_metric": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "measure", "success", "falsification"],
+      "properties": {
+        "name": {"type": "string", "minLength": 1},
+        "measure": {"type": "string", "minLength": 10},
+        "success": {"type": "string", "minLength": 5},
+        "falsification": {"type": "string", "minLength": 5}
+      }
+    },
+    "expires_at": {"type": "string", "format": "date-time"},
+    "closure": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["review_at", "allowed_outcomes", "archive_path"],
+      "properties": {
+        "review_at": {"type": "string", "format": "date-time"},
+        "allowed_outcomes": {
+          "type": "array",
+          "minItems": 3,
+          "uniqueItems": true,
+          "contains": {"const": "archive"},
+          "items": {"enum": ["promote", "reject", "archive"]}
+        },
+        "archive_path": {"type": "string", "pattern": "^proposals/_archive/[^/]+\\.json$"}
+      }
+    },
+    "boundary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["proposal_only", "no_auto_policy", "no_auto_routing", "no_queue_authority", "no_runtime_authority"],
+      "properties": {
+        "proposal_only": {"const": true},
+        "no_auto_policy": {"const": true},
+        "no_auto_routing": {"const": true},
+        "no_queue_authority": {"const": true},
+        "no_runtime_authority": {"const": true}
+      }
+    }
+  }
+}

--- a/proposals/README.md
+++ b/proposals/README.md
@@ -1,0 +1,14 @@
+# Heimlern proposal registrations
+
+Every new learning or policy-adjustment proposal is registered as `proposals/<proposal-id>.json` and must validate against `contracts/learning.proposal.registration.v1.schema.json`.
+
+The registration fails closed unless it names:
+
+- a downstream consumer and concrete use;
+- the reviewed decision and its owner;
+- a reproducible measure plus success and falsification thresholds;
+- review and expiry timestamps;
+- deterministic `promote`, `reject`, or `archive` closure;
+- proposal-only boundaries that prohibit automatic policy, routing, queue, or runtime effects.
+
+Historical reports outside `proposals/` remain readable but are not treated as active registrations. Copy `_template.json`, replace every placeholder, and keep the resulting file until one declared closure outcome is recorded and reviewed.

--- a/proposals/_template.json
+++ b/proposals/_template.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": "learning.proposal.registration.v1",
+  "proposal_id": "replace-with-stable-id",
+  "consumer": {
+    "organ": "replace-with-consumer",
+    "use": "Describe the concrete downstream use of this proposal."
+  },
+  "decision_target": {
+    "question": "Which reviewed decision will this proposal inform?",
+    "owner": "replace-with-decision-owner"
+  },
+  "success_metric": {
+    "name": "replace-with-metric",
+    "measure": "Describe how the effect will be measured reproducibly.",
+    "success": "Define the success threshold.",
+    "falsification": "Define the failure threshold."
+  },
+  "expires_at": "2026-10-10T00:00:00Z",
+  "closure": {
+    "review_at": "2026-09-10T00:00:00Z",
+    "allowed_outcomes": ["promote", "reject", "archive"],
+    "archive_path": "proposals/_archive/replace-with-stable-id.json"
+  },
+  "boundary": {
+    "proposal_only": true,
+    "no_auto_policy": true,
+    "no_auto_routing": true,
+    "no_queue_authority": true,
+    "no_runtime_authority": true
+  }
+}

--- a/scripts/validate_proposal_registrations.py
+++ b/scripts/validate_proposal_registrations.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+from jsonschema import Draft202012Validator, FormatChecker
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = ROOT / "contracts/learning.proposal.registration.v1.schema.json"
+PROPOSALS = ROOT / "proposals"
+PLACEHOLDER = "replace-with"
+
+
+def _load(path: Path) -> dict:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError(f"{path}: root must be object")
+    return value
+
+
+def validate(path: Path, *, now: datetime | None = None) -> dict:
+    payload = _load(path)
+    schema = _load(SCHEMA)
+    Draft202012Validator(schema, format_checker=FormatChecker()).validate(payload)
+    serialized = json.dumps(payload, sort_keys=True)
+    if PLACEHOLDER in serialized:
+        raise ValueError(f"{path}: unresolved template placeholder")
+    expires = datetime.fromisoformat(payload["expires_at"].replace("Z", "+00:00"))
+    review = datetime.fromisoformat(payload["closure"]["review_at"].replace("Z", "+00:00"))
+    clock = now or datetime.now(timezone.utc)
+    if expires <= clock:
+        raise ValueError(f"{path}: proposal registration already expired")
+    if review > expires:
+        raise ValueError(f"{path}: review_at must not be after expires_at")
+    expected = f"proposals/_archive/{payload['proposal_id']}.json"
+    if payload["closure"]["archive_path"] != expected:
+        raise ValueError(f"{path}: archive_path must equal {expected}")
+    return payload
+
+
+def validate_all(*, now: datetime | None = None) -> dict:
+    files = sorted(path for path in PROPOSALS.glob("*.json") if not path.name.startswith("_"))
+    ids: set[str] = set()
+    for path in files:
+        payload = validate(path, now=now)
+        proposal_id = payload["proposal_id"]
+        if proposal_id in ids:
+            raise ValueError(f"duplicate proposal_id: {proposal_id}")
+        if path.stem != proposal_id:
+            raise ValueError(f"{path}: filename must match proposal_id")
+        ids.add(proposal_id)
+    return {"status": "valid", "registrations": len(files)}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("path", nargs="?", type=Path)
+    args = parser.parse_args()
+    result = validate(args.path.resolve()) if args.path else validate_all()
+    print(json.dumps(result if args.path is None else {"status": "valid", "proposal_id": result["proposal_id"]}, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_proposal_registrations.py
+++ b/tests/test_proposal_registrations.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location("proposal_gate", ROOT / "scripts/validate_proposal_registrations.py")
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+NOW = datetime(2026, 7, 10, tzinfo=timezone.utc)
+
+
+def _valid(tmp_path: Path) -> Path:
+    payload = json.loads((ROOT / "proposals/_template.json").read_text(encoding="utf-8"))
+    payload["proposal_id"] = "routing-friction-v1"
+    payload["consumer"] = {"organ": "grabowski", "use": "Review whether routing friction falls after one bounded weight change."}
+    payload["decision_target"] = {"question": "Should the reviewed route weight be changed?", "owner": "bureau"}
+    payload["success_metric"] = {
+        "name": "blocked_run_rate",
+        "measure": "Compare blocked-run rate across equivalent pre/post windows.",
+        "success": "At least 10 percent lower.",
+        "falsification": "No reduction or a higher rate."
+    }
+    payload["closure"]["archive_path"] = "proposals/_archive/routing-friction-v1.json"
+    path = tmp_path / "routing-friction-v1.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def test_valid_registration(tmp_path: Path) -> None:
+    payload = MODULE.validate(_valid(tmp_path), now=NOW)
+    assert payload["boundary"]["no_auto_policy"] is True
+
+
+def test_missing_consumer_fails(tmp_path: Path) -> None:
+    path = _valid(tmp_path)
+    payload = json.loads(path.read_text())
+    del payload["consumer"]
+    path.write_text(json.dumps(payload))
+    with pytest.raises(Exception):
+        MODULE.validate(path, now=NOW)
+
+
+def test_expired_registration_fails(tmp_path: Path) -> None:
+    path = _valid(tmp_path)
+    payload = json.loads(path.read_text())
+    payload["expires_at"] = "2026-07-01T00:00:00Z"
+    path.write_text(json.dumps(payload))
+    with pytest.raises(ValueError, match="expired"):
+        MODULE.validate(path, now=NOW)
+
+
+def test_archive_path_is_deterministic(tmp_path: Path) -> None:
+    path = _valid(tmp_path)
+    payload = json.loads(path.read_text())
+    payload["closure"]["archive_path"] = "proposals/_archive/other.json"
+    path.write_text(json.dumps(payload))
+    with pytest.raises(ValueError, match="archive_path"):
+        MODULE.validate(path, now=NOW)


### PR DESCRIPTION
## Ergebnis

- neues Proposal-Registration-Schema mit Consumer, Entscheidungsziel, Messung, Falsifikation, Review und Ablauf
- deterministischer Abschluss über promote/reject/archive
- proposal-only Boundary verbietet automatische Policy-, Routing-, Queue- und Runtime-Wirkung
- Validator blockiert Platzhalter, abgelaufene Registrierungen, falsche Archivpfade und doppelte IDs
- CI validiert aktive Registrierungen und Negativtests
- Altberichte außerhalb `proposals/` bleiben lesbar, gelten aber nicht als aktive Registrierung

## Validierung

- Proposal-Gate: 4 Tests grün
- `cargo fmt --all --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --all --locked --workspace` grün
- `git diff --check`

Bureau task: `OPERATOR-ECOSYSTEM-REDUNDANCY-V1-T005`