### PR TITLE
fix(docs): align freshness registry with Lenskit contract

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -44,8 +44,10 @@ jobs:
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.x'
-      - name: Install jsonschema
-        run: python -m pip install --upgrade pip jsonschema pytest
+      - name: Install validation tools
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements-tools.txt
       - name: Validate sample JSONs
         run: |
           python scripts/validate_json.py \
@@ -55,6 +57,8 @@ jobs:
         run: python scripts/validate_proposal_registrations.py
       - name: Test proposal registration gate
         run: python -m pytest -q tests/test_proposal_registrations.py
+      - name: Test RepoBrief doc-freshness registry contract
+        run: python -m pytest -q tests/test_doc_freshness_registry.py
       - name: Reject invalid feedback fixture
         run: |
           if python scripts/validate_json.py contracts/policy.feedback.schema.json data/samples/policy.feedback.rejected.json; then

--- a/Justfile
+++ b/Justfile
@@ -26,7 +26,8 @@ schema-validate: venv
 	. .venv/bin/activate && python scripts/validate_json.py contracts/policy.feedback.schema.json /tmp/heimlern_feedback.json
 	python3 -m json.tool contracts/operator.routing_decision.v1.schema.json >/dev/null
 	python3 -m json.tool contracts/operator.routing_outcome.v1.schema.json >/dev/null
-	@echo "✓ alle Beispiel-Dokumente sind valide"
+	. .venv/bin/activate && python -m pytest -q tests/test_doc_freshness_registry.py
+	@echo "✓ alle Beispiel-Dokumente und das RepoBrief-Register sind valide"
 
 # Lokaler Helper: Schnelltests & Linter – sicher mit Null-Trennung und Quoting
 lint:

--- a/docs/doc-freshness-registry.md
+++ b/docs/doc-freshness-registry.md
@@ -1,6 +1,7 @@
 # Heimlern doc-freshness registry
 
 `docs/doc-freshness-registry.yml` is a minimal RepoBrief/rLens claim-evidence surface for heimlern.
+It uses the shared `lenskit.doc_freshness_registry` v1 contract. The contract kind identifies the format, not ownership of the claims; Heimlern remains the producer and owner of every entry.
 
 It records only audited, agent-relevant claims from the RepoBrief audit plan:
 

--- a/docs/doc-freshness-registry.yml
+++ b/docs/doc-freshness-registry.yml
@@ -4,11 +4,10 @@
 # This file tracks only load-bearing, agent-relevant claims from the
 # heimlern RepoBrief audit plan. It is not a general documentation index.
 
-kind: heimlern.doc_freshness_registry
+kind: lenskit.doc_freshness_registry
 version: "1.0"
 authority: diagnostic_signal
 risk_class: diagnostic
-scope: audited_agent_relevant_claims_only
 does_not_prove:
   - "a listed claim is complete or sufficient for production use"
   - "all heimlern documentation is current"
@@ -25,7 +24,7 @@ entries:
     status: done
     normative: true
     owner: contracts
-    last_verified: "2026-07-08"
+    last_verified: "2026-07-10"
     evidence:
       - kind: text
         target: "contracts/README.md::Contract Ownership & Architecture"
@@ -48,7 +47,7 @@ entries:
     status: done
     normative: true
     owner: learning-cycle
-    last_verified: "2026-07-08"
+    last_verified: "2026-07-10"
     evidence:
       - kind: text
         target: "docs/learning-cycle.md::Phasen"
@@ -65,7 +64,7 @@ entries:
     status: done
     normative: true
     owner: safety
-    last_verified: "2026-07-08"
+    last_verified: "2026-07-10"
     evidence:
       - kind: text
         target: "docs/learning-cycle.md::No Auto-Apply"
@@ -86,7 +85,7 @@ entries:
     status: done
     normative: true
     owner: heimlern-feedback
-    last_verified: "2026-07-08"
+    last_verified: "2026-07-10"
     evidence:
       - kind: symbol
         target: "crates/heimlern-feedback/src/lib.rs::WeightAdjustmentProposal"
@@ -94,7 +93,7 @@ entries:
         target: "crates/heimlern-feedback/src/lib.rs::Evidence"
       - kind: text
         target: "crates/heimlern-feedback/README.md::Weight Adjustment Proposals"
-      - kind: fixture
+      - kind: file
         target: "tests/fixtures/feedback/adjustment.ok.json"
       - kind: test
         target: "scripts/validate_weight_adjustment_coherence.py"
@@ -109,7 +108,7 @@ entries:
     status: done
     normative: false
     owner: operator-learning-axis
-    last_verified: "2026-07-08"
+    last_verified: "2026-07-10"
     evidence:
       - kind: symbol
         target: "scripts/ola_adapter.py::adapt"
@@ -117,11 +116,11 @@ entries:
         target: "scripts/ola_adapter.py::to_decision_outcome"
       - kind: symbol
         target: "scripts/ola_probe.py::probe"
-      - kind: fixture
+      - kind: file
         target: "tests/fixtures/ola/success.ok.json"
-      - kind: fixture
+      - kind: file
         target: "tests/fixtures/ola/failed.ok.json"
-      - kind: fixture
+      - kind: file
         target: "tests/fixtures/ola/failclosed.ok.json"
     notes: >-
       This is an offline observation/proposal path, not live routing control.
@@ -133,13 +132,13 @@ entries:
     status: done
     normative: false
     owner: metrics
-    last_verified: "2026-07-08"
+    last_verified: "2026-07-10"
     evidence:
-      - kind: workflow
+      - kind: file
         target: ".github/workflows/metrics.yml"
-      - kind: script
+      - kind: file
         target: "scripts/wgx-metrics-snapshot.sh"
-      - kind: schema
+      - kind: file
         target: "contracts/metrics.snapshot.schema.json"
     notes: >-
       This verifies local workflow wiring only. It does not prove scheduled GitHub

--- a/requirements-tools.txt
+++ b/requirements-tools.txt
@@ -1,2 +1,3 @@
 jsonschema>=4.22,<5
 PyYAML
+pytest>=8,<9

--- a/tests/test_doc_freshness_registry.py
+++ b/tests/test_doc_freshness_registry.py
@@ -14,17 +14,7 @@ EXPECTED_IDS = {
     "chronik-routing-outcome-ingest",
     "metrics-workflow-local-contract",
 }
-ALLOWED_EVIDENCE_KINDS = {
-    "file",
-    "fixture",
-    "sample",
-    "schema",
-    "script",
-    "symbol",
-    "test",
-    "text",
-    "workflow",
-}
+ALLOWED_EVIDENCE_KINDS = {"absent_text", "file", "proof", "symbol", "test", "text"}
 
 
 def _load_registry() -> dict:
@@ -37,11 +27,11 @@ def _load_registry() -> dict:
 def test_doc_freshness_registry_shape_and_scope() -> None:
     data = _load_registry()
 
-    assert data["kind"] == "heimlern.doc_freshness_registry"
+    assert data["kind"] == "lenskit.doc_freshness_registry"
     assert data["version"] == "1.0"
     assert data["authority"] == "diagnostic_signal"
     assert data["risk_class"] == "diagnostic"
-    assert data["scope"] == "audited_agent_relevant_claims_only"
+    assert "scope" not in data
     assert "RepoBrief or rLens is a source of task truth" in data["does_not_prove"]
 
     entries = data["entries"]


### PR DESCRIPTION
## Problem

RepoBrief konnte für Heimlern kein vollständiges Bundle mehr erzeugen. Das producer-eigene `docs/doc-freshness-registry.yml` wich vom gemeinsamen Lenskit-v1-Vertrag ab: eigener `kind`, zusätzliches `scope` und nicht unterstützte Evidenztypen.

## Änderung

- gemeinsamer Format-Kind `lenskit.doc_freshness_registry`
- producer-eigener Scope bleibt als Dokumentationsgrenze, nicht als nicht schemafähiges Feld
- `fixture`, `workflow`, `script` und `schema` werden semantisch als vorhandene `file`-Belege dargestellt
- Heimlern-Test ratcheted die gemeinsame erlaubte Typmenge
- Verifikationsdatum auf 2026-07-10 aktualisiert

## Belege

- Heimlern-Fokustests: 2 grün
- Ruff: grün
- aktuelle Lenskit-Draft-7-Schemavalidierung: PASS
- echter RepoBrief `full-max` End-to-End-Smoke: Bundle sowie `lenskit`- und `repobrief`-Manifestfamilie erfolgreich erzeugt

## Grenze

Die Änderung beweist keine inhaltliche Wahrheit oder Vollständigkeit der Claims; sie repariert ausschließlich den maschinenlesbaren gemeinsamen Vertrag.