### PR TITLE
feat: consume Chronik routing outcomes review-only

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -77,6 +77,16 @@ jobs:
           python scripts/ola_probe.py > /tmp/ola-probe.json
           python -m json.tool /tmp/ola-probe.json >/dev/null
 
+      - name: Validate review-only Chronik outcome consumer
+        run: |
+          python -m pytest -q tests/test_chronik_outcome_consumer.py
+          python scripts/chronik_outcome_consumer.py \
+            --review-time 2026-07-10T23:00:00Z \
+            --max-age-seconds 7200 \
+            tests/fixtures/chronik-outcome/operator-routing-outcome-export.v1.json \
+            > /tmp/chronik-outcome-consumer-report.json
+          python -c "import json; r=json.load(open('/tmp/chronik-outcome-consumer-report.json', encoding='utf-8')); assert r['status']=='insufficient_evidence'; assert r['review_only'] is True; assert r['writes']==[]"
+
       - name: Validate weight adjustment coherence against metarepo contract
         run: |
           mkdir -p .ci

--- a/Justfile
+++ b/Justfile
@@ -27,6 +27,8 @@ schema-validate: venv
 	python3 -m json.tool contracts/operator.routing_decision.v1.schema.json >/dev/null
 	python3 -m json.tool contracts/operator.routing_outcome.v1.schema.json >/dev/null
 	. .venv/bin/activate && python -m pytest -q tests/test_doc_freshness_registry.py
+	. .venv/bin/activate && python -m pytest -q tests/test_chronik_outcome_consumer.py
+	. .venv/bin/activate && python scripts/chronik_outcome_consumer.py --review-time 2026-07-10T23:00:00Z --max-age-seconds 7200 tests/fixtures/chronik-outcome/operator-routing-outcome-export.v1.json >/tmp/heimlern_chronik_outcome_report.json
 	@echo "✓ alle Beispiel-Dokumente und das RepoBrief-Register sind valide"
 
 # Lokaler Helper: Schnelltests & Linter – sicher mit Null-Trennung und Quoting

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -41,8 +41,10 @@ werden sie in ein standardisiertes Envelope eingebettet mit Feldern wie:
 - `ts`: Event-Zeitstempel
 - `id`: Event-ID
 
-Die Envelope-Spezifikation ist Teil der übergeordneten Event-Architektur und 
-wird im metarepo definiert.
+Die Envelope-Spezifikation ist Teil der übergeordneten Event-Architektur und
+bleibt beim jeweiligen Transport-Owner. Für Routing-Outcomes konsumiert
+Heimlern den Chronik-Contract als exakten, digest-gepinnten Mirror unter
+`contracts/mirrors/chronik/`; daraus entsteht kein Contract-Eigentum.
 
 ## Quickstart
 ```sh
@@ -62,14 +64,15 @@ just schema:validate
 | `policy.feedback.schema.json` | Feedback zu Entscheidungen | hausKI | heimlern |
 | `aussen.event.schema.json` | Externe Sensor-Events | Sensoren, APIs | heimlern, hausKI |
 
-**Schemas referenziert aus metarepo (nicht in diesem Repo):**
+**Konsumierte Schemas als exakte Mirrors (nicht Heimlern-owned):**
 
 | Schema | Zweck | Produzenten | Konsumenten |
 |--------|-------|-------------|-------------|
 | `decision.outcome.v1` | Retrospektive Outcome-Bewertung | hausKI, chronik | heimlern |
 | `policy.weight_adjustment.v1` | Gewichtsanpassungsvorschläge | heimlern | hausKI |
 
-Für Details siehe: [heimgewebe/metarepo/contracts/](https://github.com/heimgewebe/metarepo/tree/main/contracts)
+Die Mirrors liegen mit Source-Revision, Source-Pfad, SHA-256 und Non-Claims
+unter `contracts/mirrors/`. Kanonisch bleiben Chronik beziehungsweise Metarepo.
 
 ## Operator routing
 

--- a/contracts/mirrors/chronik/operator-routing-outcome-export-v1.pin.json
+++ b/contracts/mirrors/chronik/operator-routing-outcome-export-v1.pin.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "authority": "mirror_only",
+  "owner": "heimgewebe/chronik",
+  "source_repository": "heimgewebe/chronik",
+  "source_revision": "de1287423f3156cfae86c3cae6f4538732356c01",
+  "source_path": "docs/chronik/operator-routing-outcome-export-v1.schema.json",
+  "sha256": "d7c3709caaadcf599321f5abef77064631bd1a7b534346488baec595f65b3c91",
+  "expected_payload_contract": {
+    "owner": "heimgewebe/heimlern",
+    "source_repository": "heimgewebe/heimlern",
+    "source_revision": "6d70e4900377c92b540d07bd6b71fe36677c2ba5",
+    "source_path": "contracts/operator.routing_outcome.v1.schema.json",
+    "sha256": "cff1f19814d33dd0ba084b3b5d9e2d4b6c36b1276dab35c3256912b5c457712d"
+  },
+  "does_not_establish": [
+    "heimlern_owns_chronik_envelope",
+    "automatic_mirror_refresh",
+    "chronik_runtime_readiness"
+  ]
+}

--- a/contracts/mirrors/chronik/operator-routing-outcome-export-v1.schema.json
+++ b/contracts/mirrors/chronik/operator-routing-outcome-export-v1.schema.json
@@ -1,0 +1,110 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://heimgewebe.local/chronik/operator-routing-outcome-export-v1.schema.json",
+  "title": "Chronik Operator Routing Outcome Export v1",
+  "description": "A digest-bound Chronik transport envelope around a Heimlern-owned operator.routing_outcome.v1 payload.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "event_id",
+    "kind",
+    "ts",
+    "source",
+    "payload_contract",
+    "payload_sha256",
+    "payload",
+    "freshness",
+    "evidence_refs",
+    "boundary",
+    "non_claims"
+  ],
+  "properties": {
+    "schema_version": {"const": "chronik.operator-routing-outcome-export.v1"},
+    "event_id": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+    "kind": {"const": "operator.routing_outcome.exported"},
+    "ts": {"$ref": "#/$defs/utc_second"},
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["repo", "component", "revision", "run_id"],
+      "properties": {
+        "repo": {"const": "heimgewebe/grabowski"},
+        "component": {"type": "string", "pattern": "^[A-Za-z0-9._-]{1,120}$"},
+        "revision": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
+        "run_id": {"type": "string", "pattern": "^[A-Za-z0-9._:-]{1,160}$"}
+      }
+    },
+    "payload_contract": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["owner", "source_repository", "source_revision", "source_path", "sha256"],
+      "properties": {
+        "owner": {"const": "heimgewebe/heimlern"},
+        "source_repository": {"const": "heimgewebe/heimlern"},
+        "source_revision": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
+        "source_path": {"const": "contracts/operator.routing_outcome.v1.schema.json"},
+        "sha256": {"$ref": "#/$defs/sha256_hex"}
+      }
+    },
+    "payload_sha256": {"$ref": "#/$defs/sha256_hex"},
+    "payload": {"type": "object"},
+    "freshness": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["observed_at", "exported_at", "consumer_must_recompute"],
+      "properties": {
+        "observed_at": {"$ref": "#/$defs/utc_second"},
+        "exported_at": {"$ref": "#/$defs/utc_second"},
+        "consumer_must_recompute": {"const": true}
+      }
+    },
+    "evidence_refs": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 8,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["kind", "ref", "sha256"],
+        "properties": {
+          "kind": {"type": "string", "pattern": "^[a-z][a-z0-9._:-]{0,80}$"},
+          "ref": {"type": "string", "minLength": 1, "maxLength": 240},
+          "sha256": {"$ref": "#/$defs/sha256_hex"}
+        }
+      }
+    },
+    "boundary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["transport_authority", "payload_authority", "routing_authority", "raw_logs_included", "secrets_included", "auto_apply_permitted"],
+      "properties": {
+        "transport_authority": {"const": "chronik_append_only_history"},
+        "payload_authority": {"const": "heimlern_contract_at_pinned_revision"},
+        "routing_authority": {"const": "none"},
+        "raw_logs_included": {"const": false},
+        "secrets_included": {"const": false},
+        "auto_apply_permitted": {"const": false}
+      }
+    },
+    "non_claims": {
+      "type": "array",
+      "minItems": 5,
+      "maxItems": 5,
+      "uniqueItems": true,
+      "items": {
+        "enum": [
+          "routing_policy_superiority",
+          "production_sample_sufficiency",
+          "automatic_application_permission",
+          "chronik_payload_contract_ownership",
+          "runtime_readiness"
+        ]
+      }
+    }
+  },
+  "$defs": {
+    "sha256_hex": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "utc_second": {"type": "string", "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$"}
+  }
+}

--- a/contracts/mirrors/metarepo/policy.weight_adjustment.v1.pin.json
+++ b/contracts/mirrors/metarepo/policy.weight_adjustment.v1.pin.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 1,
+  "authority": "mirror_only",
+  "owner": "heimgewebe/metarepo",
+  "source_repository": "heimgewebe/metarepo",
+  "source_revision": "10daa1c84469dce76e93cdc24c47c1dfc5e156d6",
+  "source_path": "contracts/policy.weight_adjustment.v1.schema.json",
+  "sha256": "5998e43de8465e55a133294c16231377cfd1c7d66a06bfab3d22f83d17170e78",
+  "does_not_establish": [
+    "heimlern_owns_policy_weight_contract",
+    "automatic_mirror_refresh",
+    "proposal_application_permission"
+  ]
+}

--- a/contracts/mirrors/metarepo/policy.weight_adjustment.v1.schema.json
+++ b/contracts/mirrors/metarepo/policy.weight_adjustment.v1.schema.json
@@ -1,0 +1,128 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.heimgewebe.org/contracts/policy.weight_adjustment.v1.schema.json",
+  "title": "heimlern policy weight adjustment proposal v1",
+  "x-producers": ["heimlern"],
+  "x-consumers": ["hausKI", "chronik"],
+  "type": "object",
+  "required": ["version", "basis_policy", "ts", "deltas", "confidence", "evidence"],
+  "properties": {
+    "version": {
+      "type": "string",
+      "const": "v1"
+    },
+    "basis_policy": {
+      "type": "string",
+      "description": "ID/Hash der Policy, auf der diese Anpassung basiert."
+    },
+    "ts": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "deltas": {
+      "type": "object",
+      "description": "Map von Policy-ID zu Delta-Objekt.",
+      "minProperties": 1,
+      "propertyNames": {
+        "pattern": "^[a-zA-Z0-9_.-]+$",
+        "description": "Keys must be valid identifiers (alphanumeric, dot, underscore, dash)."
+      },
+      "additionalProperties": {
+        "oneOf": [
+          {
+            "description": "Absolute adjustment.",
+            "type": "object",
+            "properties": {
+              "kind": { "const": "absolute" },
+              "value": { "type": "number", "description": "New absolute value." },
+              "unit": {
+                "type": "string",
+                "enum": ["weight", "probability", "score", "factor"],
+                "description": "Optional unit for absolute values (e.g., 'weight', 'probability', 'score', 'factor')."
+              }
+            },
+            "required": ["kind", "value"],
+            "additionalProperties": false
+          },
+          {
+            "description": "Relative adjustment.",
+            "type": "object",
+            "properties": {
+              "kind": { "const": "relative" },
+              "value": { "type": "number", "minimum": -5.0, "maximum": 5.0, "description": "Relative multiplier or percentage change." },
+              "unit": {
+                "type": "string",
+                "enum": ["percent", "factor"],
+                "description": "Unit required for relative changes to clarify semantics. Must be either 'percent' or 'factor'."
+              }
+            },
+            "required": ["kind", "value", "unit"],
+            "additionalProperties": false
+          }
+        ]
+      }
+    },
+    "confidence": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1,
+      "description": "Confidence score for this adjustment."
+    },
+    "decisions_analyzed": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Number of decisions that contributed to this adjustment."
+    },
+    "status": {
+      "type": "string",
+      "enum": ["proposed", "accepted", "rejected", "superseded"],
+      "description": "Status of this adjustment proposal."
+    },
+    "reasoning": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Explanation for the adjustment. Required if status is not 'proposed'."
+    },
+    "evidence": {
+      "type": "object",
+      "description": "Evidence or simulation results backing this adjustment.",
+      "properties": {
+        "decisions_analyzed": { "type": "integer", "minimum": 0 },
+        "failure_rate_before": { "type": "number", "minimum": 0, "maximum": 1 },
+        "failure_rate_after_sim": {
+          "type": "number",
+          "description": "Projected failure rate after applying the adjustment."
+        },
+        "simulation_method": {
+          "type": "string",
+          "description": "The method used for simulation. Required if failure_rate_after_sim is present."
+        },
+        "patterns": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      },
+      "additionalProperties": false,
+      "allOf": [
+        {
+          "if": { "required": ["failure_rate_after_sim"] },
+          "then": { "required": ["simulation_method"] }
+        },
+        {
+          "if": { "required": ["simulation_method"] },
+          "then": { "required": ["failure_rate_after_sim"] }
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "allOf": [
+    {
+      "if": {
+        "properties": { "status": { "enum": ["accepted", "rejected", "superseded"] } },
+        "required": ["status"]
+      },
+      "then": { "required": ["reasoning"] }
+    }
+  ]
+}

--- a/docs/chronik-routing-outcome-consumer.md
+++ b/docs/chronik-routing-outcome-consumer.md
@@ -1,0 +1,79 @@
+# Chronik routing-outcome consumer
+
+Status: review-only contract consumer
+
+Bureau task: `CHRONIK-HEIMLERN-OUTCOME-BRIDGE-V1-T003`
+
+## Role boundary
+
+Heimlern consumes a Chronik-owned append-only envelope around the Heimlern-owned
+`operator.routing_outcome.v1` payload. The consumer validates and analyzes; it
+does not fetch Chronik, append events, change route weights or apply proposals.
+
+Authority stays separated:
+
+| Surface | Owner | Consumer treatment |
+| --- | --- | --- |
+| Transport envelope | `heimgewebe/chronik` | exact digest-pinned mirror |
+| Routing-outcome payload | `heimgewebe/heimlern` | canonical local contract |
+| Weight-adjustment proposal | `heimgewebe/metarepo` | exact digest-pinned mirror |
+| Execution receipts and future producer | `heimgewebe/grabowski` | not implemented by this slice |
+
+## Validation order
+
+`scripts/chronik_outcome_consumer.py` fails closed before analysis unless all of
+the following hold:
+
+1. Both external mirrors match their source revision/path SHA-256 pins and remain
+   marked `mirror_only`.
+2. The Chronik envelope and embedded Heimlern payload validate against their
+   respective schemas.
+3. `payload_contract`, canonical payload SHA-256 and deterministic event ID
+   match the pinned identities.
+4. Outer and payload evidence references carry the same non-duplicated digests.
+5. Envelope export time equals `ts`, payload time equals `observed_at`, and no
+   export lies in the future relative to the supplied review time.
+6. Raw-output fields, secret-shaped strings and private absolute paths are
+   rejected before schema errors can echo input values.
+7. Input bytes, event size and event count remain bounded.
+8. Duplicate event and decision IDs are ignored deterministically; conflicting decision payloads fail closed; stale events are excluded
+   under the explicit consumer-side freshness policy.
+9. Proposal timestamps are bound to the explicit review time rather than the
+   machine clock, and Rust adapter calls are time-bounded.
+
+Only fresh, unique payloads reach the existing OLA analysis path. A resulting
+proposal must validate against the pinned `policy.weight_adjustment.v1` mirror.
+Otherwise the output is a typed `insufficient_evidence`, `proposal_blocked` or
+`invalid_input` result.
+
+## Usage
+
+The review time is explicit in reproducible runs. Without it, current UTC is
+used.
+
+```bash
+python scripts/chronik_outcome_consumer.py \
+  --review-time 2026-07-10T23:00:00Z \
+  --max-age-seconds 7200 \
+  tests/fixtures/chronik-outcome/operator-routing-outcome-export.v1.json
+```
+
+The JSON report includes accepted event IDs and envelope digests, event/decision duplicates,
+stale exclusions, contract revisions/digests, analysis output, proposal
+validation, `writes: []` and explicit non-claims.
+
+## Mirror update rule
+
+A mirror update is a reviewed contract migration, not an automatic refresh:
+
+1. read the canonical source at an immutable revision;
+2. replace the mirror with exact bytes;
+3. update revision, path and SHA-256 in the adjacent pin;
+4. inspect semantic differences and update compatibility tests;
+5. run the full repository CI before merge.
+
+## Non-claims
+
+This consumer does not establish a live Grabowski producer, Chronik runtime
+readiness, production sample sufficiency, causal route superiority, routing
+policy readiness or permission to apply a proposal.

--- a/docs/doc-freshness-registry.yml
+++ b/docs/doc-freshness-registry.yml
@@ -102,28 +102,30 @@ entries:
       not prove proposal quality or suitability for automatic application.
 
   - id: chronik-routing-outcome-ingest
-    doc: docs/operator-ecosystem-alignment.md
-    locator: "Operator ecosystem alignment"
-    claim: "heimlern can consume redacted Grabowski or Chronik-style outcomes as offline learning inputs without receiving live routing authority."
+    doc: docs/chronik-routing-outcome-consumer.md
+    locator: "Chronik routing-outcome consumer"
+    claim: "heimlern validates digest-pinned Chronik routing-outcome envelopes and consumes only fresh, unique, redacted payloads as review-only offline learning inputs."
     status: done
     normative: false
     owner: operator-learning-axis
-    last_verified: "2026-07-10"
+    last_verified: "2026-07-11"
     evidence:
       - kind: symbol
-        target: "scripts/ola_adapter.py::adapt"
+        target: "scripts/chronik_outcome_consumer.py::consume_exports"
       - kind: symbol
-        target: "scripts/ola_adapter.py::to_decision_outcome"
-      - kind: symbol
-        target: "scripts/ola_probe.py::probe"
+        target: "scripts/ola_probe.py::probe_routing_outcomes"
       - kind: file
-        target: "tests/fixtures/ola/success.ok.json"
+        target: "contracts/mirrors/chronik/operator-routing-outcome-export-v1.pin.json"
       - kind: file
-        target: "tests/fixtures/ola/failed.ok.json"
+        target: "contracts/mirrors/metarepo/policy.weight_adjustment.v1.pin.json"
       - kind: file
-        target: "tests/fixtures/ola/failclosed.ok.json"
+        target: "tests/fixtures/chronik-outcome/operator-routing-outcome-export.v1.json"
+      - kind: test
+        target: "tests/test_chronik_outcome_consumer.py"
     notes: >-
-      This is an offline observation/proposal path, not live routing control.
+      This proves a fixture-equivalent review-only consumer, not a live
+      Grabowski producer, Chronik runtime readiness, production sample
+      sufficiency or permission to apply proposals.
 
   - id: metrics-workflow-local-contract
     doc: .github/workflows/metrics.yml

--- a/docs/operator-ecosystem-alignment.md
+++ b/docs/operator-ecosystem-alignment.md
@@ -2,10 +2,20 @@
 
 Heimlern is the retrospective learning and policy-adaptation proposal engine of the Heimgewebe operator ecosystem.
 
-- Chronik provides historical events and outcomes.
+- Chronik owns the append-only routing-outcome transport envelope and historical export.
 - Bureau owns tasks, claims and completion truth.
 - Grabowski owns local execution and receipts.
 - Leitstand may display learning reports and proposals.
-- Heimlern may propose adjustments; it must not silently apply them.
+- Heimlern owns the routing-outcome payload and may propose adjustments; it must not silently apply them.
 
 The useful loop is evidence -> outcome analysis -> auditable proposal -> separate decision gate. Anything shorter is just a model wearing a lab coat.
+
+
+## Review-only Chronik outcome path
+
+The dedicated consumer validates pinned Chronik and Metarepo mirrors, the local
+Heimlern payload contract, canonical event/payload identities, evidence digests,
+redaction, freshness and duplicates before OLA analysis. It emits an auditable
+report or schema-valid proposal candidate with `writes: []`. The generic
+`AussenEvent` ingest path is deliberately not reused for routing outcomes. See
+`docs/chronik-routing-outcome-consumer.md`.

--- a/scripts/chronik_outcome_consumer.py
+++ b/scripts/chronik_outcome_consumer.py
@@ -1,0 +1,675 @@
+#!/usr/bin/env python3
+"""Validate Chronik routing-outcome envelopes and analyze them review-only.
+
+The consumer owns no transport or routing policy. It validates exact mirror
+pins, both contract layers, deterministic identities, freshness and redaction
+before delegating already-normalized routing outcomes to Heimlern's OLA probe.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+from jsonschema import Draft202012Validator, FormatChecker, ValidationError
+
+from ola_probe import probe_routing_outcomes
+
+ROOT = Path(__file__).resolve().parents[1]
+ENVELOPE_SCHEMA_PATH = ROOT / "contracts/mirrors/chronik/operator-routing-outcome-export-v1.schema.json"
+ENVELOPE_PIN_PATH = ROOT / "contracts/mirrors/chronik/operator-routing-outcome-export-v1.pin.json"
+PAYLOAD_SCHEMA_PATH = ROOT / "contracts/operator.routing_outcome.v1.schema.json"
+PROPOSAL_SCHEMA_PATH = ROOT / "contracts/mirrors/metarepo/policy.weight_adjustment.v1.schema.json"
+PROPOSAL_PIN_PATH = ROOT / "contracts/mirrors/metarepo/policy.weight_adjustment.v1.pin.json"
+
+_RAW_KEYS = {"raw_log", "raw_logs", "stdout", "stderr", "command_output", "log_excerpt"}
+_PRIVATE_PATH_RE = re.compile(r"(?<![A-Za-z0-9._-])/(?:home|root|Users)/")
+_SECRET_ASSIGNMENT_RE = re.compile(
+    r"\b(?:api[_-]?key|token|secret|password)\s*[:=]\s*\S+", re.IGNORECASE
+)
+_SECRET_TOKEN_RE = re.compile(
+    r"\b(?:bearer\s+\S+|gh[pousr]_[A-Za-z0-9_]{20,}|sk-[A-Za-z0-9_-]{20,}|AKIA[0-9A-Z]{16})\b",
+    re.IGNORECASE,
+)
+_PRIVATE_KEY_RE = re.compile(
+    r"-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----", re.IGNORECASE
+)
+_HEX_REVISION_RE = re.compile(r"^[0-9a-f]{40}$")
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+_MAX_EXPORTS = 100
+_MAX_EXPORT_BYTES = 1024 * 1024
+_MAX_TOTAL_INPUT_BYTES = 16 * 1024 * 1024
+_ALLOWED_ANALYSIS_STATUSES = {
+    "insufficient_evidence",
+    "proposal_candidate",
+    "proposal_blocked",
+}
+_DOES_NOT_ESTABLISH = [
+    "routing_policy_readiness",
+    "automatic_application_permission",
+    "production_sample_sufficiency",
+    "chronik_runtime_readiness",
+    "live_grabowski_producer",
+    "causal_route_superiority",
+]
+
+
+class ConsumerError(ValueError):
+    """Fail-closed typed consumer error."""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+@dataclass(frozen=True)
+class ContractIdentity:
+    envelope_revision: str
+    envelope_sha256: str
+    payload_revision: str
+    payload_sha256: str
+    proposal_revision: str
+    proposal_sha256: str
+
+
+@dataclass(frozen=True)
+class ValidatedEnvelope:
+    event_id: str
+    payload: dict[str, Any]
+    observed_at: datetime
+    exported_at: datetime
+    canonical_sha256: str
+
+
+def _reject_constant(value: str) -> None:
+    raise ConsumerError("json_non_finite_number", f"non-finite JSON number {value} is forbidden")
+
+
+def _object_without_duplicates(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    value: dict[str, Any] = {}
+    for key, item in pairs:
+        if key in value:
+            raise ConsumerError("json_duplicate_key", "duplicate JSON key")
+        value[key] = item
+    return value
+
+
+def _strict_json_loads(text: str, *, label: str) -> Any:
+    try:
+        return json.loads(
+            text,
+            object_pairs_hook=_object_without_duplicates,
+            parse_constant=_reject_constant,
+        )
+    except ConsumerError:
+        raise
+    except json.JSONDecodeError as exc:
+        raise ConsumerError("json_invalid", f"{label}: {exc}") from exc
+
+
+def _path_label(path: Path) -> str:
+    return path.name or "<input>"
+
+
+def _load_object(path: Path) -> dict[str, Any]:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise ConsumerError("json_read_failed", f"{_path_label(path)}: read failed") from exc
+    value = _strict_json_loads(text, label=_path_label(path))
+    if not isinstance(value, dict):
+        raise ConsumerError(
+            "json_object_required", f"{_path_label(path)} must contain a JSON object"
+        )
+    return value
+
+
+def canonical_json_bytes(value: Any) -> bytes:
+    try:
+        text = json.dumps(
+            value,
+            allow_nan=False,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+    except (TypeError, ValueError) as exc:
+        raise ConsumerError("json_not_canonicalizable", str(exc)) from exc
+    return text.encode("utf-8")
+
+
+def sha256_json(value: Any) -> str:
+    return hashlib.sha256(canonical_json_bytes(value)).hexdigest()
+
+
+def event_id_for(export: dict[str, Any]) -> str:
+    without_id = dict(export)
+    without_id.pop("event_id", None)
+    return "sha256:" + sha256_json(without_id)
+
+
+def _file_sha256(path: Path) -> str:
+    try:
+        content = path.read_bytes()
+    except OSError as exc:
+        raise ConsumerError("mirror_read_failed", f"{_path_label(path)}: read failed") from exc
+    return hashlib.sha256(content).hexdigest()
+
+
+def _validate_pin(
+    pin_path: Path,
+    mirror_path: Path,
+    *,
+    expected_owner: str,
+    expected_repository: str,
+    expected_path: str,
+    expected_non_claims: set[str],
+) -> dict[str, Any]:
+    pin = _load_object(pin_path)
+    if pin.get("schema_version") != 1:
+        raise ConsumerError("mirror_pin_version_invalid", "mirror pin schema_version must be 1")
+    if not _HEX_REVISION_RE.fullmatch(str(pin.get("source_revision") or "")):
+        raise ConsumerError("mirror_revision_invalid", "mirror source_revision must be a commit SHA")
+    if not _SHA256_RE.fullmatch(str(pin.get("sha256") or "")):
+        raise ConsumerError("mirror_sha256_invalid", "mirror sha256 must be lowercase hex")
+    if pin.get("authority") != "mirror_only":
+        raise ConsumerError("mirror_authority_invalid", f"{pin_path} must remain mirror_only")
+    if pin.get("owner") != expected_owner:
+        raise ConsumerError("mirror_owner_invalid", f"{pin_path} owner is not {expected_owner}")
+    if pin.get("source_repository") != expected_repository:
+        raise ConsumerError(
+            "mirror_repository_invalid",
+            f"{pin_path} source repository is not {expected_repository}",
+        )
+    if pin.get("source_path") != expected_path:
+        raise ConsumerError(
+            "mirror_path_invalid", f"{pin_path} source path is not {expected_path}"
+        )
+    if set(pin.get("does_not_establish", [])) != expected_non_claims:
+        raise ConsumerError("mirror_non_claims_invalid", f"{pin_path} non-claims are incomplete")
+    actual = _file_sha256(mirror_path)
+    if actual != pin.get("sha256"):
+        raise ConsumerError(
+            "mirror_digest_mismatch",
+            f"{mirror_path} sha256 {actual} does not match pin {pin.get('sha256')}",
+        )
+    return pin
+
+
+def load_contracts() -> tuple[ContractIdentity, dict[str, Any], dict[str, Any], dict[str, Any], dict[str, Any]]:
+    envelope_pin = _validate_pin(
+        ENVELOPE_PIN_PATH,
+        ENVELOPE_SCHEMA_PATH,
+        expected_owner="heimgewebe/chronik",
+        expected_repository="heimgewebe/chronik",
+        expected_path="docs/chronik/operator-routing-outcome-export-v1.schema.json",
+        expected_non_claims={
+            "heimlern_owns_chronik_envelope",
+            "automatic_mirror_refresh",
+            "chronik_runtime_readiness",
+        },
+    )
+    proposal_pin = _validate_pin(
+        PROPOSAL_PIN_PATH,
+        PROPOSAL_SCHEMA_PATH,
+        expected_owner="heimgewebe/metarepo",
+        expected_repository="heimgewebe/metarepo",
+        expected_path="contracts/policy.weight_adjustment.v1.schema.json",
+        expected_non_claims={
+            "heimlern_owns_policy_weight_contract",
+            "automatic_mirror_refresh",
+            "proposal_application_permission",
+        },
+    )
+    payload_sha256 = _file_sha256(PAYLOAD_SCHEMA_PATH)
+    expected_payload = envelope_pin.get("expected_payload_contract")
+    expected_payload_identity = {
+        "owner": "heimgewebe/heimlern",
+        "source_repository": "heimgewebe/heimlern",
+        "source_path": "contracts/operator.routing_outcome.v1.schema.json",
+    }
+    if not isinstance(expected_payload, dict) or any(
+        expected_payload.get(key) != value
+        for key, value in expected_payload_identity.items()
+    ):
+        raise ConsumerError(
+            "payload_contract_identity_invalid",
+            "Chronik pin does not identify the canonical Heimlern payload contract",
+        )
+    if not _HEX_REVISION_RE.fullmatch(str(expected_payload.get("source_revision") or "")):
+        raise ConsumerError(
+            "payload_contract_revision_invalid",
+            "Heimlern payload contract revision must be a commit SHA",
+        )
+    if not _SHA256_RE.fullmatch(str(expected_payload.get("sha256") or "")):
+        raise ConsumerError(
+            "payload_contract_sha256_invalid",
+            "Heimlern payload contract sha256 must be lowercase hex",
+        )
+    if payload_sha256 != expected_payload.get("sha256"):
+        raise ConsumerError(
+            "payload_contract_drift",
+            "local operator.routing_outcome.v1 schema does not match the Chronik mirror pin",
+        )
+
+    envelope_schema = _load_object(ENVELOPE_SCHEMA_PATH)
+    payload_schema = _load_object(PAYLOAD_SCHEMA_PATH)
+    proposal_schema = _load_object(PROPOSAL_SCHEMA_PATH)
+    for label, schema in (
+        ("envelope", envelope_schema),
+        ("payload", payload_schema),
+        ("proposal", proposal_schema),
+    ):
+        try:
+            Draft202012Validator.check_schema(schema)
+        except Exception as exc:
+            raise ConsumerError("schema_invalid", f"{label} schema is invalid: {exc}") from exc
+
+    identity = ContractIdentity(
+        envelope_revision=str(envelope_pin["source_revision"]),
+        envelope_sha256=str(envelope_pin["sha256"]),
+        payload_revision=str(expected_payload["source_revision"]),
+        payload_sha256=payload_sha256,
+        proposal_revision=str(proposal_pin["source_revision"]),
+        proposal_sha256=str(proposal_pin["sha256"]),
+    )
+    return identity, envelope_pin, envelope_schema, payload_schema, proposal_schema
+
+
+def _parse_utc(value: str, *, label: str) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except (AttributeError, ValueError) as exc:
+        raise ConsumerError("timestamp_invalid", f"{label} must be an RFC3339 timestamp") from exc
+    if parsed.tzinfo is None or parsed.utcoffset() != timezone.utc.utcoffset(parsed):
+        raise ConsumerError("timestamp_not_utc", f"{label} must be UTC")
+    if parsed.microsecond != 0:
+        raise ConsumerError("timestamp_precision_invalid", f"{label} must use whole seconds")
+    return parsed.astimezone(timezone.utc)
+
+
+def _walk(value: Any, *, path: str = "$") -> Iterable[tuple[str, str, Any]]:
+    if isinstance(value, dict):
+        for key, item in value.items():
+            yield path, str(key), item
+            yield from _walk(item, path=f"{path}.{key}")
+    elif isinstance(value, list):
+        for index, item in enumerate(value):
+            yield from _walk(item, path=f"{path}[{index}]")
+
+
+def _contains_sensitive_text(value: str) -> bool:
+    return bool(
+        _PRIVATE_PATH_RE.search(value)
+        or _PRIVATE_KEY_RE.search(value)
+        or _SECRET_TOKEN_RE.search(value)
+        or _SECRET_ASSIGNMENT_RE.search(value)
+    )
+
+
+def _validate_redaction(export: dict[str, Any]) -> None:
+    for path, key, value in _walk(export):
+        if _contains_sensitive_text(key):
+            raise ConsumerError(
+                "sensitive_key_forbidden", "sensitive material in JSON key is forbidden"
+            )
+        if key.lower() in _RAW_KEYS:
+            raise ConsumerError("raw_output_forbidden", f"raw output field at {path}.{key}")
+        if not isinstance(value, str):
+            continue
+        if _PRIVATE_PATH_RE.search(value):
+            raise ConsumerError("private_path_forbidden", "private absolute path is forbidden")
+        if _PRIVATE_KEY_RE.search(value) or _SECRET_TOKEN_RE.search(value) or _SECRET_ASSIGNMENT_RE.search(value):
+            raise ConsumerError("secret_material_forbidden", "secret-shaped text is forbidden")
+
+
+def _validate_evidence_identity(export: dict[str, Any]) -> None:
+    outer = export.get("evidence_refs")
+    inner = export.get("payload", {}).get("evidence_refs")
+    if not isinstance(outer, list) or not isinstance(inner, list):
+        raise ConsumerError("evidence_refs_missing", "outer and payload evidence_refs are required")
+
+    def normalize(items: list[Any]) -> list[tuple[str, str, str]]:
+        normalized: list[tuple[str, str, str]] = []
+        seen: dict[tuple[str, str], str] = {}
+        for item in items:
+            if not isinstance(item, dict):
+                raise ConsumerError("evidence_ref_invalid", "evidence ref must be an object")
+            key = (str(item.get("kind") or ""), str(item.get("ref") or ""))
+            digest = str(item.get("sha256") or "")
+            previous = seen.get(key)
+            if previous is not None:
+                if previous != digest:
+                    raise ConsumerError(
+                        "evidence_digest_conflict", "conflicting digest for evidence ref"
+                    )
+                raise ConsumerError("evidence_ref_duplicate", "duplicate evidence ref")
+            seen[key] = digest
+            normalized.append((key[0], key[1], digest))
+        return sorted(normalized)
+
+    if normalize(outer) != normalize(inner):
+        raise ConsumerError(
+            "evidence_identity_mismatch",
+            "transport evidence refs do not match payload evidence refs",
+        )
+
+
+def validate_envelope(
+    export: dict[str, Any],
+    *,
+    envelope_pin: dict[str, Any],
+    envelope_schema: dict[str, Any],
+    payload_schema: dict[str, Any],
+) -> ValidatedEnvelope:
+    canonical_size = len(canonical_json_bytes(export))
+    if canonical_size > _MAX_EXPORT_BYTES:
+        raise ConsumerError(
+            "export_too_large",
+            f"canonical export exceeds {_MAX_EXPORT_BYTES} bytes",
+        )
+    _validate_redaction(export)
+
+    format_checker = FormatChecker()
+    try:
+        Draft202012Validator(envelope_schema, format_checker=format_checker).validate(export)
+    except ValidationError as exc:
+        raise ConsumerError("envelope_schema_invalid", exc.message) from exc
+
+    if export.get("payload_contract") != envelope_pin.get("expected_payload_contract"):
+        raise ConsumerError(
+            "payload_contract_mismatch",
+            "envelope payload_contract does not match the pinned Heimlern contract",
+        )
+
+    payload = export.get("payload")
+    if not isinstance(payload, dict):
+        raise ConsumerError("payload_object_required", "payload must be an object")
+    try:
+        Draft202012Validator(payload_schema, format_checker=format_checker).validate(payload)
+    except ValidationError as exc:
+        raise ConsumerError("payload_schema_invalid", exc.message) from exc
+
+    payload_sha256 = sha256_json(payload)
+    if export.get("payload_sha256") != payload_sha256:
+        raise ConsumerError("payload_digest_mismatch", "payload_sha256 does not match canonical payload bytes")
+    expected_event_id = event_id_for(export)
+    if export.get("event_id") != expected_event_id:
+        raise ConsumerError("event_identity_mismatch", "event_id does not match canonical export bytes")
+
+    _validate_evidence_identity(export)
+
+    observed_at = _parse_utc(export["freshness"]["observed_at"], label="freshness.observed_at")
+    exported_at = _parse_utc(export["freshness"]["exported_at"], label="freshness.exported_at")
+    event_ts = _parse_utc(export["ts"], label="ts")
+    if exported_at < observed_at:
+        raise ConsumerError("freshness_inverted", "exported_at precedes observed_at")
+    if event_ts != exported_at:
+        raise ConsumerError("event_timestamp_mismatch", "ts must equal freshness.exported_at")
+    payload_ts = _parse_utc(payload["ts"], label="payload.ts")
+    if payload_ts != observed_at:
+        raise ConsumerError(
+            "payload_observation_mismatch",
+            "payload.ts must equal freshness.observed_at",
+        )
+
+    return ValidatedEnvelope(
+        event_id=str(export["event_id"]),
+        payload=payload,
+        observed_at=observed_at,
+        exported_at=exported_at,
+        canonical_sha256=hashlib.sha256(canonical_json_bytes(export)).hexdigest(),
+    )
+
+
+def consume_exports(
+    exports: list[dict[str, Any]],
+    *,
+    review_time: datetime,
+    max_age_seconds: int,
+    min_decisions: int,
+) -> dict[str, Any]:
+    if not exports:
+        raise ConsumerError("input_empty", "at least one Chronik export is required")
+    if len(exports) > _MAX_EXPORTS:
+        raise ConsumerError(
+            "input_count_exceeded", f"at most {_MAX_EXPORTS} exports are accepted"
+        )
+    if max_age_seconds < 0:
+        raise ConsumerError("freshness_policy_invalid", "max_age_seconds must be non-negative")
+    if min_decisions < 1:
+        raise ConsumerError("analysis_policy_invalid", "min_decisions must be at least 1")
+    if review_time.tzinfo is None:
+        raise ConsumerError("review_time_invalid", "review_time must be timezone-aware")
+    review_time = review_time.astimezone(timezone.utc)
+
+    identity, envelope_pin, envelope_schema, payload_schema, proposal_schema = load_contracts()
+    validated = [
+        validate_envelope(
+            export,
+            envelope_pin=envelope_pin,
+            envelope_schema=envelope_schema,
+            payload_schema=payload_schema,
+        )
+        for export in exports
+    ]
+
+    unique: dict[str, ValidatedEnvelope] = {}
+    duplicate_event_ids: list[str] = []
+    for item in sorted(validated, key=lambda value: (value.event_id, value.canonical_sha256)):
+        previous = unique.get(item.event_id)
+        if previous is None:
+            unique[item.event_id] = item
+            continue
+        if previous.canonical_sha256 != item.canonical_sha256:
+            raise ConsumerError("event_id_collision", f"different exports share {item.event_id}")
+        duplicate_event_ids.append(item.event_id)
+
+    decisions: dict[str, ValidatedEnvelope] = {}
+    duplicate_decision_ids: list[str] = []
+    for item in sorted(unique.values(), key=lambda value: (value.payload["decision_id"], value.event_id)):
+        decision_id = str(item.payload["decision_id"])
+        previous = decisions.get(decision_id)
+        if previous is None:
+            decisions[decision_id] = item
+            continue
+        if sha256_json(previous.payload) != sha256_json(item.payload):
+            raise ConsumerError(
+                "decision_identity_conflict",
+                f"different payloads share decision_id {decision_id}",
+            )
+        duplicate_decision_ids.append(decision_id)
+
+    fresh: list[ValidatedEnvelope] = []
+    stale: list[dict[str, Any]] = []
+    for item in sorted(decisions.values(), key=lambda value: (value.observed_at, value.event_id)):
+        age_seconds = int((review_time - item.observed_at).total_seconds())
+        if item.exported_at > review_time:
+            raise ConsumerError("future_export", f"{item.event_id} was exported after review_time")
+        if age_seconds < 0:
+            raise ConsumerError("future_observation", f"{item.event_id} is newer than review_time")
+        if age_seconds > max_age_seconds:
+            stale.append({"event_id": item.event_id, "age_seconds": age_seconds, "reason": "stale"})
+        else:
+            fresh.append(item)
+
+    try:
+        analysis = probe_routing_outcomes(
+            [item.payload for item in fresh],
+            min_decisions=min_decisions,
+            proposal_ts=review_time.replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+        )
+    except (OSError, RuntimeError, ValueError, json.JSONDecodeError) as exc:
+        raise ConsumerError("analysis_failed", f"OLA analysis failed: {exc}") from exc
+    if not isinstance(analysis, dict) or analysis.get("status") not in _ALLOWED_ANALYSIS_STATUSES:
+        raise ConsumerError("analysis_invalid", "OLA analysis returned an invalid status")
+    if not isinstance(analysis.get("summary"), dict):
+        raise ConsumerError("analysis_invalid", "OLA analysis returned no summary")
+
+    proposal = analysis.get("proposal")
+    proposal_validation: dict[str, Any]
+    if proposal is None:
+        proposal_validation = {
+            "status": "not_applicable",
+            "contract_revision": identity.proposal_revision,
+            "contract_sha256": identity.proposal_sha256,
+        }
+    else:
+        try:
+            Draft202012Validator(
+                proposal_schema, format_checker=FormatChecker()
+            ).validate(proposal)
+        except ValidationError as exc:
+            raise ConsumerError("proposal_schema_invalid", exc.message) from exc
+        proposal_validation = {
+            "status": "valid",
+            "contract_revision": identity.proposal_revision,
+            "contract_sha256": identity.proposal_sha256,
+        }
+
+    return {
+        "schema_version": 1,
+        "kind": "chronik_operator_outcome_consumer_report",
+        "status": analysis["status"],
+        "review_only": True,
+        "input": {
+            "received": len(exports),
+            "unique_events": len(unique),
+            "duplicate_events_ignored": len(duplicate_event_ids),
+            "duplicate_event_ids": sorted(duplicate_event_ids),
+            "unique_decisions": len(decisions),
+            "duplicate_decisions_ignored": len(duplicate_decision_ids),
+            "duplicate_decision_ids": sorted(duplicate_decision_ids),
+            "fresh": len(fresh),
+            "stale_excluded": len(stale),
+        },
+        "accepted": [
+            {
+                "event_id": item.event_id,
+                "envelope_sha256": item.canonical_sha256,
+                "observed_at": item.observed_at.isoformat().replace("+00:00", "Z"),
+                "exported_at": item.exported_at.isoformat().replace("+00:00", "Z"),
+                "age_seconds": int((review_time - item.observed_at).total_seconds()),
+            }
+            for item in fresh
+        ],
+        "freshness_policy": {
+            "review_time": review_time.replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+            "max_age_seconds": max_age_seconds,
+            "consumer_recomputed": True,
+        },
+        "stale": stale,
+        "analysis_policy": {
+            "min_decisions": min_decisions,
+            "review_only": True,
+        },
+        "contracts": {
+            "chronik_envelope": {
+                "revision": identity.envelope_revision,
+                "sha256": identity.envelope_sha256,
+                "authority": "mirror_only",
+            },
+            "heimlern_payload": {
+                "revision": identity.payload_revision,
+                "sha256": identity.payload_sha256,
+                "authority": "canonical_local_contract",
+            },
+            "weight_adjustment_proposal": {
+                "revision": identity.proposal_revision,
+                "sha256": identity.proposal_sha256,
+                "authority": "mirror_only",
+            },
+        },
+        "analysis": analysis,
+        "proposal_validation": proposal_validation,
+        "writes": [],
+        "does_not_establish": _DOES_NOT_ESTABLISH,
+    }
+
+
+def _read_exports(paths: list[Path]) -> list[dict[str, Any]]:
+    exports: list[dict[str, Any]] = []
+    total_bytes = 0
+    for path in paths:
+        try:
+            content = path.read_bytes()
+        except OSError as exc:
+            raise ConsumerError(
+                "json_read_failed", f"{_path_label(path)}: read failed"
+            ) from exc
+        total_bytes += len(content)
+        if total_bytes > _MAX_TOTAL_INPUT_BYTES:
+            raise ConsumerError(
+                "input_bytes_exceeded",
+                f"input exceeds {_MAX_TOTAL_INPUT_BYTES} bytes",
+            )
+        try:
+            text = content.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise ConsumerError(
+                "json_encoding_invalid", f"{_path_label(path)}: UTF-8 required"
+            ) from exc
+        value = _strict_json_loads(text, label=_path_label(path))
+        if isinstance(value, dict):
+            exports.append(value)
+        elif isinstance(value, list) and all(isinstance(item, dict) for item in value):
+            exports.extend(value)
+        else:
+            raise ConsumerError(
+                "json_exports_required",
+                f"{_path_label(path)} must contain an object or array of objects",
+            )
+        if len(exports) > _MAX_EXPORTS:
+            raise ConsumerError(
+                "input_count_exceeded", f"at most {_MAX_EXPORTS} exports are accepted"
+            )
+    return exports
+
+
+def _invalid_report(exc: ConsumerError) -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "kind": "chronik_operator_outcome_consumer_report",
+        "status": "invalid_input",
+        "review_only": True,
+        "error": {"code": exc.code, "message": str(exc)},
+        "analysis": None,
+        "proposal_validation": {"status": "not_run"},
+        "writes": [],
+        "does_not_establish": _DOES_NOT_ESTABLISH,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("inputs", nargs="+", type=Path)
+    parser.add_argument("--review-time", help="RFC3339 UTC timestamp; defaults to current UTC")
+    parser.add_argument("--max-age-seconds", type=int, default=86400)
+    parser.add_argument("--min-decisions", type=int, default=10)
+    args = parser.parse_args()
+    try:
+        review_time = (
+            _parse_utc(args.review_time, label="review_time")
+            if args.review_time
+            else datetime.now(timezone.utc).replace(microsecond=0)
+        )
+        report = consume_exports(
+            _read_exports(args.inputs),
+            review_time=review_time,
+            max_age_seconds=args.max_age_seconds,
+            min_decisions=args.min_decisions,
+        )
+    except ConsumerError as exc:
+        print(json.dumps(_invalid_report(exc), ensure_ascii=False, indent=2, sort_keys=True))
+        return 1
+    print(json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ola_adapter.py
+++ b/scripts/ola_adapter.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
+import shutil
 import subprocess
 import tempfile
 from datetime import datetime, timezone
@@ -20,6 +22,7 @@ DEFAULT_POLICY_ID = "grabowski-routing-v0"
 _ROUTE_DELTA_KEY_INVALID = "route_delta_key_invalid"
 _ROUTE_DELTA_KEY_COLLISION = "route_delta_key_collision"
 _ROUTE_DELTA_KEY_ERROR_KINDS = frozenset({_ROUTE_DELTA_KEY_INVALID, _ROUTE_DELTA_KEY_COLLISION})
+_OLA_COMMAND_TIMEOUT_SECONDS = 300
 
 
 class RouteDeltaKeyError(ValueError):
@@ -36,6 +39,16 @@ def repo_root() -> Path:
     return Path(__file__).resolve().parents[1]
 
 
+def cargo_binary() -> str:
+    configured = shutil.which("cargo")
+    if configured:
+        return configured
+    user_cargo = Path.home() / ".cargo" / "bin" / "cargo"
+    if user_cargo.is_file() and os.access(user_cargo, os.X_OK):
+        return str(user_cargo)
+    raise RuntimeError("cargo executable not found in PATH or ~/.cargo/bin")
+
+
 def iso_now() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
@@ -48,15 +61,19 @@ def _json_from_text(text: str) -> dict[str, Any]:
 
 
 def _run_ola(args: list[str]) -> dict[str, Any]:
-    cmd = ["cargo", "run", "-q", "-p", "heimlern-cli", "--bin", "heimlern-ola", "--", *args]
-    result = subprocess.run(
-        cmd,
-        cwd=repo_root(),
-        text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        check=False,
-    )
+    cmd = [cargo_binary(), "run", "-q", "-p", "heimlern-cli", "--bin", "heimlern-ola", "--", *args]
+    try:
+        result = subprocess.run(
+            cmd,
+            cwd=repo_root(),
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+            timeout=_OLA_COMMAND_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError("heimlern-ola command timed out") from exc
     if result.returncode != 0:
         raise RuntimeError(result.stderr.strip() or result.stdout.strip() or f"heimlern-ola exited {result.returncode}")
     return _json_from_text(result.stdout)
@@ -79,7 +96,7 @@ def to_decision_outcome(routing_outcome: dict[str, Any], policy_id: str = DEFAUL
 
 def route_delta_key(action: str) -> tuple[str, str]:
     cmd = [
-        "cargo",
+        cargo_binary(),
         "run",
         "-q",
         "-p",
@@ -90,14 +107,18 @@ def route_delta_key(action: str) -> tuple[str, str]:
         "route-delta-key",
         action,
     ]
-    result = subprocess.run(
-        cmd,
-        cwd=repo_root(),
-        text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        check=False,
-    )
+    try:
+        result = subprocess.run(
+            cmd,
+            cwd=repo_root(),
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+            timeout=_OLA_COMMAND_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError("heimlern-ola command timed out") from exc
     if result.returncode != 0:
         try:
             payload = _json_from_text(result.stderr)
@@ -113,9 +134,10 @@ def route_delta_key(action: str) -> tuple[str, str]:
 
 def run_self_test() -> None:
     subprocess.run(
-        ["cargo", "test", "-q", "-p", "heimlern-core", "ola::"],
+        [cargo_binary(), "test", "-q", "-p", "heimlern-core", "ola::"],
         cwd=repo_root(),
         check=True,
+        timeout=_OLA_COMMAND_TIMEOUT_SECONDS,
     )
     sample = {
         "decision_id": "gr-example-001",

--- a/scripts/ola_probe.py
+++ b/scripts/ola_probe.py
@@ -97,7 +97,14 @@ def summarize(decision_outcomes: list[dict[str, Any]]) -> dict[str, Any]:
     }
 
 
-def maybe_propose(summary: dict[str, Any], min_decisions: int, min_action_count: int, failure_threshold: float) -> dict[str, Any] | None:
+def maybe_propose(
+    summary: dict[str, Any],
+    min_decisions: int,
+    min_action_count: int,
+    failure_threshold: float,
+    *,
+    proposal_ts: str | None = None,
+) -> dict[str, Any] | None:
     if summary["total"] < min_decisions:
         return None
     deltas: dict[str, Any] = {}
@@ -125,7 +132,7 @@ def maybe_propose(summary: dict[str, Any], min_decisions: int, min_action_count:
     return {
         "version": "v1",
         "basis_policy": DEFAULT_POLICY_ID,
-        "ts": iso_now(),
+        "ts": proposal_ts or iso_now(),
         "deltas": deltas,
         "confidence": confidence,
         "evidence": {
@@ -140,12 +147,23 @@ def maybe_propose(summary: dict[str, Any], min_decisions: int, min_action_count:
     }
 
 
-def probe(inputs: list[dict[str, Any]], min_decisions: int = DEFAULT_MIN_DECISIONS) -> dict[str, Any]:
-    routing_outcomes = [adapt(item) for item in inputs]
+def probe_routing_outcomes(
+    routing_outcomes: list[dict[str, Any]],
+    min_decisions: int = DEFAULT_MIN_DECISIONS,
+    *,
+    proposal_ts: str | None = None,
+) -> dict[str, Any]:
+    """Analyze already contract-valid routing outcomes without adapting them twice."""
     decision_outcomes = [to_decision_outcome(item) for item in routing_outcomes]
     summary = summarize(decision_outcomes)
     try:
-        proposal = maybe_propose(summary, min_decisions, DEFAULT_MIN_ACTION_COUNT, DEFAULT_FAILURE_THRESHOLD)
+        proposal = maybe_propose(
+            summary,
+            min_decisions,
+            DEFAULT_MIN_ACTION_COUNT,
+            DEFAULT_FAILURE_THRESHOLD,
+            proposal_ts=proposal_ts,
+        )
     except RouteDeltaKeyError as exc:
         return {
             "schema_version": 1,
@@ -167,6 +185,11 @@ def probe(inputs: list[dict[str, Any]], min_decisions: int = DEFAULT_MIN_DECISIO
         "proposal": proposal,
         "does_not_establish": list(_DOES_NOT_ESTABLISH),
     }
+
+
+def probe(inputs: list[dict[str, Any]], min_decisions: int = DEFAULT_MIN_DECISIONS) -> dict[str, Any]:
+    routing_outcomes = [adapt(item) for item in inputs]
+    return probe_routing_outcomes(routing_outcomes, min_decisions)
 
 
 def run_self_test() -> None:

--- a/tests/fixtures/chronik-outcome/operator-routing-outcome-export.v1.json
+++ b/tests/fixtures/chronik-outcome/operator-routing-outcome-export.v1.json
@@ -1,0 +1,80 @@
+{
+  "schema_version": "chronik.operator-routing-outcome-export.v1",
+  "kind": "operator.routing_outcome.exported",
+  "ts": "2026-07-10T22:41:00Z",
+  "source": {
+    "repo": "heimgewebe/grabowski",
+    "component": "operator-outcome-export",
+    "revision": "6a169c5f8f580907b64a51ba797b2d8bcc93b3e0",
+    "run_id": "outcome-export-20260710-001"
+  },
+  "payload_contract": {
+    "owner": "heimgewebe/heimlern",
+    "source_repository": "heimgewebe/heimlern",
+    "source_revision": "6d70e4900377c92b540d07bd6b71fe36677c2ba5",
+    "source_path": "contracts/operator.routing_outcome.v1.schema.json",
+    "sha256": "cff1f19814d33dd0ba084b3b5d9e2d4b6c36b1276dab35c3256912b5c457712d"
+  },
+  "payload_sha256": "c9843409b700342bfeb4539179895547a1a14e168b7dd240ba762aaee61af207",
+  "payload": {
+    "version": "operator.routing_outcome.v1",
+    "decision_id": "grabowski-route-20260710-001",
+    "ts": "2026-07-10T22:40:00Z",
+    "task_class": "contract_slice",
+    "route_used": "typed_tool",
+    "outcome": "success",
+    "resolved": true,
+    "reward": 0.8,
+    "metrics": {
+      "completion_state": "completed",
+      "friction_count": 0,
+      "blocked_by_platform_filter": false,
+      "manual_operator_needed": false,
+      "ci_state": "pass",
+      "pr_state": "merged",
+      "elapsed_seconds": 420,
+      "rework_count": 1
+    },
+    "friction": [],
+    "evidence_refs": [
+      {
+        "kind": "receipt",
+        "ref": "grabowski-task:example-outcome-001",
+        "sha256": "1111111111111111111111111111111111111111111111111111111111111111"
+      }
+    ],
+    "does_not_establish": [
+      "causal_route_superiority",
+      "routing_policy_readiness",
+      "auto_apply_permission"
+    ]
+  },
+  "freshness": {
+    "observed_at": "2026-07-10T22:40:00Z",
+    "exported_at": "2026-07-10T22:41:00Z",
+    "consumer_must_recompute": true
+  },
+  "evidence_refs": [
+    {
+      "kind": "receipt",
+      "ref": "grabowski-task:example-outcome-001",
+      "sha256": "1111111111111111111111111111111111111111111111111111111111111111"
+    }
+  ],
+  "boundary": {
+    "transport_authority": "chronik_append_only_history",
+    "payload_authority": "heimlern_contract_at_pinned_revision",
+    "routing_authority": "none",
+    "raw_logs_included": false,
+    "secrets_included": false,
+    "auto_apply_permitted": false
+  },
+  "non_claims": [
+    "routing_policy_superiority",
+    "production_sample_sufficiency",
+    "automatic_application_permission",
+    "chronik_payload_contract_ownership",
+    "runtime_readiness"
+  ],
+  "event_id": "sha256:e4062c86598a9995552bfeb238705c3ad7c50ec10df93ea2c92ef26a1ddc991c"
+}

--- a/tests/test_chronik_outcome_consumer.py
+++ b/tests/test_chronik_outcome_consumer.py
@@ -1,0 +1,444 @@
+from __future__ import annotations
+
+import copy
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+import chronik_outcome_consumer as consumer  # noqa: E402
+
+FIXTURE = ROOT / "tests/fixtures/chronik-outcome/operator-routing-outcome-export.v1.json"
+REVIEW_TIME = datetime(2026, 7, 10, 23, 0, 0, tzinfo=timezone.utc)
+
+
+def load_fixture() -> dict:
+    return json.loads(FIXTURE.read_text(encoding="utf-8"))
+
+
+def rehash(export: dict) -> dict:
+    export["payload_sha256"] = consumer.sha256_json(export["payload"])
+    export["event_id"] = consumer.event_id_for(export)
+    return export
+
+
+def consume(exports: list[dict], **kwargs) -> dict:
+    return consumer.consume_exports(
+        exports,
+        review_time=kwargs.get("review_time", REVIEW_TIME),
+        max_age_seconds=kwargs.get("max_age_seconds", 7200),
+        min_decisions=kwargs.get("min_decisions", 10),
+    )
+
+
+def assert_error(code: str, export: dict) -> None:
+    with pytest.raises(consumer.ConsumerError) as caught:
+        consume([export])
+    assert caught.value.code == code
+
+
+def failed_export(index: int) -> dict:
+    export = load_fixture()
+    export["source"]["run_id"] = f"outcome-export-failed-{index:03d}"
+    payload = export["payload"]
+    payload["decision_id"] = f"grabowski-route-failed-{index:03d}"
+    evidence_ref = f"grabowski-task:failed-{index:03d}"
+    payload["evidence_refs"][0]["ref"] = evidence_ref
+    export["evidence_refs"][0]["ref"] = evidence_ref
+    payload["route_used"] = "direct:patch"
+    payload["outcome"] = "failure"
+    payload["resolved"] = False
+    payload["reward"] = -0.8
+    payload["metrics"].update(
+        {
+            "completion_state": "failed",
+            "friction_count": 1,
+            "ci_state": "fail",
+            "pr_state": "closed",
+            "rework_count": 2,
+        }
+    )
+    payload["friction"] = [
+        {
+            "kind": "operator_bug",
+            "surface": "local_tool",
+            "operation": "patch_apply",
+            "resolved": False,
+            "fallback": "stopped without mutation",
+        }
+    ]
+    return rehash(export)
+
+
+def test_valid_fixture_is_review_only_and_insufficient() -> None:
+    report = consume([load_fixture()])
+    assert report["status"] == "insufficient_evidence"
+    assert report["review_only"] is True
+    assert report["input"] == {
+        "received": 1,
+        "unique_events": 1,
+        "duplicate_events_ignored": 0,
+        "duplicate_event_ids": [],
+        "unique_decisions": 1,
+        "duplicate_decisions_ignored": 0,
+        "duplicate_decision_ids": [],
+        "fresh": 1,
+        "stale_excluded": 0,
+    }
+    assert report["analysis"]["summary"]["total"] == 1
+    assert report["accepted"][0]["event_id"] == load_fixture()["event_id"]
+    assert report["proposal_validation"]["status"] == "not_applicable"
+    assert report["writes"] == []
+
+
+def test_duplicate_event_is_ignored_deterministically(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        consumer,
+        "probe_routing_outcomes",
+        lambda payloads, min_decisions, proposal_ts=None: {
+            "schema_version": 1,
+            "kind": "ola_analyzer_probe",
+            "status": "insufficient_evidence",
+            "summary": {"total": len(payloads)},
+            "proposal": None,
+            "does_not_establish": [],
+        },
+    )
+    export = load_fixture()
+    report = consume([copy.deepcopy(export), copy.deepcopy(export)])
+    assert report["input"]["received"] == 2
+    assert report["input"]["unique_events"] == 1
+    assert report["input"]["duplicate_events_ignored"] == 1
+    assert report["input"]["duplicate_event_ids"] == [export["event_id"]]
+    assert report["analysis"]["summary"]["total"] == 1
+
+
+def test_stale_event_is_excluded_and_freshness_is_recomputed() -> None:
+    report = consume(
+        [load_fixture()],
+        review_time=datetime(2026, 7, 12, 0, 0, 0, tzinfo=timezone.utc),
+        max_age_seconds=60,
+    )
+    assert report["status"] == "insufficient_evidence"
+    assert report["input"]["fresh"] == 0
+    assert report["input"]["stale_excluded"] == 1
+    assert report["freshness_policy"]["consumer_recomputed"] is True
+    assert report["analysis"]["summary"]["total"] == 0
+
+
+def test_payload_contract_drift_is_rejected() -> None:
+    export = load_fixture()
+    export["payload_contract"]["source_revision"] = "0" * 40
+    export["event_id"] = consumer.event_id_for(export)
+    assert_error("payload_contract_mismatch", export)
+
+
+def test_payload_digest_mismatch_is_rejected() -> None:
+    export = load_fixture()
+    export["payload"]["reward"] = 0.7
+    assert_error("payload_digest_mismatch", export)
+
+
+def test_event_identity_mismatch_is_rejected() -> None:
+    export = load_fixture()
+    export["source"]["run_id"] = "changed-run"
+    assert_error("event_identity_mismatch", export)
+
+
+def test_evidence_digest_identity_mismatch_is_rejected() -> None:
+    export = load_fixture()
+    export["evidence_refs"][0]["sha256"] = "2" * 64
+    export["event_id"] = consumer.event_id_for(export)
+    assert_error("evidence_identity_mismatch", export)
+
+
+def test_secret_shaped_text_is_rejected_before_analysis() -> None:
+    export = load_fixture()
+    export["payload"]["metrics"]["friction_count"] = 1
+    export["payload"]["friction"] = [
+        {
+            "kind": "unknown",
+            "surface": "runtime",
+            "resolved": False,
+            "fallback": "Authorization: " + "Bearer " + "example-value",
+        }
+    ]
+    assert_error("secret_material_forbidden", rehash(export))
+
+
+def test_private_absolute_path_is_rejected_before_analysis() -> None:
+    export = load_fixture()
+    export["payload"]["metrics"]["friction_count"] = 1
+    export["payload"]["friction"] = [
+        {
+            "kind": "unknown",
+            "surface": "runtime",
+            "resolved": False,
+            "fallback": "/home/example/private/receipt.json",
+        }
+    ]
+    assert_error("private_path_forbidden", rehash(export))
+
+
+def test_event_newer_than_review_time_is_rejected() -> None:
+    export = load_fixture()
+    with pytest.raises(consumer.ConsumerError) as caught:
+        consume(
+            [export],
+            review_time=datetime(2026, 7, 10, 22, 0, 0, tzinfo=timezone.utc),
+        )
+    assert caught.value.code == "future_export"
+
+
+def test_failed_corpus_produces_schema_valid_review_only_proposal() -> None:
+    report = consume([failed_export(index) for index in range(10)])
+    assert report["status"] == "proposal_candidate"
+    assert report["analysis"]["proposal"] is not None
+    assert report["proposal_validation"]["status"] == "valid"
+    assert report["analysis"]["proposal"]["status"] == "proposed"
+    assert report["analysis"]["proposal"]["evidence"]["decisions_analyzed"] == 10
+    assert report["writes"] == []
+    assert "automatic_application_permission" in report["does_not_establish"]
+
+
+def test_cli_emits_machine_readable_invalid_input(tmp_path: Path) -> None:
+    export = load_fixture()
+    export["event_id"] = "sha256:" + "0" * 64
+    path = tmp_path / "invalid.json"
+    path.write_text(json.dumps(export), encoding="utf-8")
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "scripts/chronik_outcome_consumer.py"),
+            "--review-time",
+            "2026-07-10T23:00:00Z",
+            str(path),
+        ],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert completed.returncode == 1
+    report = json.loads(completed.stdout)
+    assert report["status"] == "invalid_input"
+    assert report["error"]["code"] == "event_identity_mismatch"
+    assert report["writes"] == []
+
+
+def test_empty_input_is_rejected() -> None:
+    with pytest.raises(consumer.ConsumerError) as caught:
+        consume([])
+    assert caught.value.code == "input_empty"
+
+
+def test_future_export_is_rejected_even_when_observation_is_older() -> None:
+    export = load_fixture()
+    export["ts"] = "2026-07-10T23:01:00Z"
+    export["freshness"]["exported_at"] = "2026-07-10T23:01:00Z"
+    export["event_id"] = consumer.event_id_for(export)
+    assert_error("future_export", export)
+
+
+def test_payload_timestamp_must_match_observation_timestamp() -> None:
+    export = load_fixture()
+    export["payload"]["ts"] = "2026-07-10T22:39:00Z"
+    assert_error("payload_observation_mismatch", rehash(export))
+
+
+def test_mirror_digest_drift_is_rejected(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    drifted = tmp_path / "chronik-envelope.schema.json"
+    drifted.write_bytes(consumer.ENVELOPE_SCHEMA_PATH.read_bytes() + b"\n")
+    monkeypatch.setattr(consumer, "ENVELOPE_SCHEMA_PATH", drifted)
+    with pytest.raises(consumer.ConsumerError) as caught:
+        consume([load_fixture()])
+    assert caught.value.code == "mirror_digest_mismatch"
+
+
+def test_mirror_source_identity_is_fail_closed(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    pin = json.loads(consumer.ENVELOPE_PIN_PATH.read_text(encoding="utf-8"))
+    pin["source_repository"] = "heimgewebe/other"
+    bad_pin = tmp_path / "chronik-envelope.pin.json"
+    bad_pin.write_text(json.dumps(pin), encoding="utf-8")
+    monkeypatch.setattr(consumer, "ENVELOPE_PIN_PATH", bad_pin)
+    with pytest.raises(consumer.ConsumerError) as caught:
+        consume([load_fixture()])
+    assert caught.value.code == "mirror_repository_invalid"
+
+
+def test_missing_mirror_is_reported_as_typed_error(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(consumer, "ENVELOPE_SCHEMA_PATH", tmp_path / "missing.json")
+    with pytest.raises(consumer.ConsumerError) as caught:
+        consume([load_fixture()])
+    assert caught.value.code == "mirror_read_failed"
+
+
+def test_rust_analysis_failure_is_reported_as_typed_error(
+    monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def fail_analysis(payloads, min_decisions, proposal_ts=None):
+        raise RuntimeError("heimlern-ola unavailable")
+
+    monkeypatch.setattr(consumer, "probe_routing_outcomes", fail_analysis)
+    with pytest.raises(consumer.ConsumerError) as caught:
+        consume([load_fixture()])
+    assert caught.value.code == "analysis_failed"
+
+
+def test_duplicate_decision_is_not_double_counted() -> None:
+    first = load_fixture()
+    second = copy.deepcopy(first)
+    second["source"]["run_id"] = "outcome-export-replay-002"
+    second["event_id"] = consumer.event_id_for(second)
+    report = consume([first, second])
+    assert report["input"]["unique_events"] == 2
+    assert report["input"]["unique_decisions"] == 1
+    assert report["input"]["duplicate_decisions_ignored"] == 1
+    assert report["input"]["duplicate_decision_ids"] == [
+        first["payload"]["decision_id"]
+    ]
+    assert report["analysis"]["summary"]["total"] == 1
+
+
+def test_conflicting_duplicate_decision_is_rejected() -> None:
+    first = load_fixture()
+    second = copy.deepcopy(first)
+    second["source"]["run_id"] = "outcome-export-conflict-002"
+    second["payload"]["reward"] = 0.7
+    rehash(second)
+    with pytest.raises(consumer.ConsumerError) as caught:
+        consume([first, second])
+    assert caught.value.code == "decision_identity_conflict"
+
+
+def test_redaction_runs_before_schema_error_and_does_not_echo_value() -> None:
+    export = load_fixture()
+    export["unexpected"] = "Authorization: " + "Bearer " + "sensitive-example"
+    with pytest.raises(consumer.ConsumerError) as caught:
+        consume([export])
+    assert caught.value.code == "secret_material_forbidden"
+    assert "sensitive-example" not in str(caught.value)
+
+
+def test_input_count_is_bounded(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(consumer, "_MAX_EXPORTS", 1)
+    with pytest.raises(consumer.ConsumerError) as caught:
+        consume([load_fixture(), load_fixture()])
+    assert caught.value.code == "input_count_exceeded"
+
+
+def test_duplicate_json_keys_are_rejected(tmp_path: Path) -> None:
+    path = tmp_path / "duplicate.json"
+    path.write_text('{"schema_version":1,"schema_version":2}', encoding="utf-8")
+    with pytest.raises(consumer.ConsumerError) as caught:
+        consumer._read_exports([path])
+    assert caught.value.code == "json_duplicate_key"
+    assert "schema_version" not in str(caught.value)
+
+
+def test_non_finite_json_numbers_are_rejected(tmp_path: Path) -> None:
+    path = tmp_path / "nan.json"
+    path.write_text('{"value":NaN}', encoding="utf-8")
+    with pytest.raises(consumer.ConsumerError) as caught:
+        consumer._read_exports([path])
+    assert caught.value.code == "json_non_finite_number"
+
+
+def test_analysis_result_shape_is_fail_closed(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(consumer, "probe_routing_outcomes", lambda *_args, **_kwargs: {})
+    with pytest.raises(consumer.ConsumerError) as caught:
+        consume([load_fixture()])
+    assert caught.value.code == "analysis_invalid"
+
+
+def test_pin_revision_and_payload_identity_are_fail_closed(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    canonical_pin_path = consumer.ENVELOPE_PIN_PATH
+    canonical_pin = json.loads(canonical_pin_path.read_text(encoding="utf-8"))
+
+    bad_revision = dict(canonical_pin)
+    bad_revision["source_revision"] = "main"
+    bad_pin = tmp_path / "chronik.pin.json"
+    bad_pin.write_text(json.dumps(bad_revision), encoding="utf-8")
+    monkeypatch.setattr(consumer, "ENVELOPE_PIN_PATH", bad_pin)
+    with pytest.raises(consumer.ConsumerError) as caught:
+        consume([load_fixture()])
+    assert caught.value.code == "mirror_revision_invalid"
+
+    bad_identity = json.loads(canonical_pin_path.read_text(encoding="utf-8"))
+    bad_identity["expected_payload_contract"]["owner"] = "heimgewebe/other"
+    bad_pin.write_text(json.dumps(bad_identity), encoding="utf-8")
+    with pytest.raises(consumer.ConsumerError) as caught:
+        consume([load_fixture()])
+    assert caught.value.code == "payload_contract_identity_invalid"
+
+
+def test_review_time_requires_whole_seconds() -> None:
+    with pytest.raises(consumer.ConsumerError) as caught:
+        consumer._parse_utc("2026-07-10T23:00:00.500Z", label="review_time")
+    assert caught.value.code == "timestamp_precision_invalid"
+
+
+def test_redaction_catches_case_variants_uri_paths_and_sensitive_keys() -> None:
+    values = [
+        "authorization: bearer example-value",
+        "file:///home/example/private.json",
+        "-----BEGIN RSA " + "PRIVATE KEY-----",
+    ]
+    expected = ["secret_material_forbidden", "private_path_forbidden", "secret_material_forbidden"]
+    for value, code in zip(values, expected):
+        export = load_fixture()
+        export["payload"]["metrics"]["friction_count"] = 1
+        export["payload"]["friction"] = [{
+            "kind": "unknown",
+            "surface": "runtime",
+            "resolved": False,
+            "fallback": value,
+        }]
+        with pytest.raises(consumer.ConsumerError) as caught:
+            consume([rehash(export)])
+        assert caught.value.code == code
+        assert value not in str(caught.value)
+
+    export = load_fixture()
+    export["Authorization: Bearer example-value"] = "x"
+    with pytest.raises(consumer.ConsumerError) as caught:
+        consume([export])
+    assert caught.value.code == "sensitive_key_forbidden"
+    assert "example-value" not in str(caught.value)
+
+
+def test_proposal_timestamp_is_bound_to_review_time() -> None:
+    report = consume([failed_export(index) for index in range(10)])
+    assert report["analysis"]["proposal"]["ts"] == "2026-07-10T23:00:00Z"
+
+
+def test_rust_timeout_is_converted_to_typed_analysis_error(
+    monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import subprocess
+    import ola_adapter
+
+    def timeout(*_args, **_kwargs):
+        raise subprocess.TimeoutExpired(cmd=["heimlern-ola"], timeout=1)
+
+    monkeypatch.setattr(ola_adapter.subprocess, "run", timeout)
+    with pytest.raises(consumer.ConsumerError) as caught:
+        consume([load_fixture()])
+    assert caught.value.code == "analysis_failed"
+    assert "timed out" in str(caught.value)


### PR DESCRIPTION
## Summary

- add a dedicated review-only consumer for `chronik.operator-routing-outcome-export.v1` instead of reusing the unrelated `AussenEvent` path
- bind exact Chronik envelope and Metarepo proposal mirrors to immutable revisions, paths and SHA-256 pins while keeping Heimlern's payload contract canonical locally
- validate strict JSON, both contract layers, contract identities, canonical payload/event digests, evidence identity, redaction, timestamps and bounded input sizes before analysis
- recompute freshness at review time, deduplicate event and decision identities, and fail closed on conflicting decisions
- bind proposal timestamps to the explicit review time and validate every candidate against the corrected `policy.weight_adjustment.v1` contract
- emit only auditable review reports with `writes: []`; no fetch, append, routing mutation or proposal application
- make Rust adapter discovery and timeouts deterministic

## Upstream contract fix

Implementation uncovered a duplicate top-level `required` key in Metarepo's proposal schema, which silently weakened required-field enforcement. Metarepo PR #645 fixed the canonical contract before this PR pinned it at merge `10daa1c84469dce76e93cdc24c47c1dfc5e156d6`.

## Validation

- Python: 37 passed
- Rust workspace: 76 passed plus doc tests
- cargo fmt: pass
- cargo clippy `-D warnings`: pass
- schema validation: pass
- proposal registrations: valid
- OLA adapter/probe self-tests: pass
- strict mirror and fixture JSON: pass
- changed-file sensitivity scan: pass
- `git diff --check`: pass
- fixture smoke: `insufficient_evidence`, `review_only=true`, `writes=[]`

Bureau task: `CHRONIK-HEIMLERN-OUTCOME-BRIDGE-V1-T003`

## Non-claims

This does not establish a live Grabowski producer, Chronik runtime readiness, production sample sufficiency, causal route superiority, routing-policy readiness or permission to apply a proposal.