### PR TITLE
fix(security): update vulnerable Rust dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -622,9 +622,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha",
@@ -732,9 +732,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
## Summary

- update `rustls-webpki` from 0.103.9 to 0.103.13
- update `rand` from 0.8.5 to 0.8.6
- address the five currently open Heimlern Dependabot alerts without changing source APIs or application behavior

## Live alert basis

- one high-severity `rustls-webpki` CRL denial-of-service alert
- one medium-severity `rustls-webpki` CRL matching alert
- two low-severity `rustls-webpki` name-constraint alerts
- one low-severity `rand` soundness alert

## Validation

- cargo fmt: pass
- cargo clippy `-D warnings`: pass
- Rust workspace: 76 tests passed plus doc tests
- Python: 37 tests passed
- schema validation: pass
- `git diff --check`: pass

Only `Cargo.lock` changes.