### PR TITLE
docs: mark legacy system context historical

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,14 +142,11 @@ In einem Binary kann ein einfacher Subscriber gesetzt werden:
 }
 ```
 
-## Organismus-Kontext
+## Systemkontext
 
-Dieses Repository ist Teil des **Heimgewebe-Organismus**.
+`heimlern` ist eine historische Referenz und keine aktive Lernkomponente. Der aktuelle Status
+der Heimgewebe-Systeme wird im [Systemkatalog](https://github.com/heimgewebe/systemkatalog) geführt; die
+[gerenderte Systemübersicht](https://github.com/heimgewebe/systemkatalog/blob/main/rendered/system-catalog.md)
+ist die lesbare Gesamtsicht.
 
-Die übergeordnete Architektur, Achsen, Rollen und Contracts sind zentral beschrieben im  
-👉 [`metarepo/docs/system/heimgewebe-organismus.md`](https://github.com/heimgewebe/metarepo/blob/main/docs/heimgewebe-organismus.md)  
-sowie im Zielbild  
-👉 [`metarepo/docs/heimgewebe-zielbild.md`](https://github.com/heimgewebe/metarepo/blob/main/docs/heimgewebe-zielbild.md).
-
-Alle Rollen-Definitionen, Datenflüsse und Contract-Zuordnungen dieses Repos
-sind dort verankert.
+Die historische Implementierungs- und Entscheidungsdokumentation bleibt in diesem Repository.

--- a/docs/learning-cycle.md
+++ b/docs/learning-cycle.md
@@ -1,6 +1,11 @@
 # Learning Cycle Workflow
 
-Dieses Dokument beschreibt den vollständigen Lernzyklus im Heimgewebe-Organismus zwischen **hausKI** (Entscheider) und **heimlern** (Lerner).
+> **Historischer Stand:** Dieser Ablauf dokumentiert die frühere Zielarchitektur zwischen
+> `hausKI` und `heimlern`. Er ist keine aktuelle Betriebs- oder Rollenwahrheit. Aktuelle
+> Systemzwecke und Lifecycle-Stände werden im [Systemkatalog](https://github.com/heimgewebe/systemkatalog) geführt.
+
+Dieses Dokument beschreibt den früher vorgesehenen Lernzyklus zwischen **hausKI** (Entscheider)
+und **heimlern** (Lerner).
 
 ## Übersicht
 


### PR DESCRIPTION
## Zweck

Heimlern ist eine historische Referenz und darf durch alte Organismusverweise nicht als aktive Lernkomponente erscheinen.

## Änderung

- README nennt Heimlern ausdrücklich historische Referenz
- frühere Lernzyklus-Zielarchitektur als historisch und nicht aktuell markiert
- historischer ADR-Verweis bewusst unverändert erhalten
- aktueller Systemstatus an den Systemkatalog delegiert

## Prüfung

- Rustfmt und Clippy grün
- 76 Rust-Tests und 6 Python-Tests bestanden
- Feedback-Schemavalidierung bestanden
- T006-Drift-, Ziel- und Whitespace-Gate bestanden

Bureau: `METAREPO-LEGACY-RECONCILIATION-V1-T006`