### PR TITLE
chore: declare Heimlern ready for archival

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -53,6 +53,8 @@ jobs:
           python scripts/validate_json.py \
           --schemas contracts/ \
           --samples data/samples/
+      - name: Validate archive readiness and contract authority
+        run: python scripts/validate_archive_readiness.py
       - name: Validate active proposal registrations
         run: python scripts/validate_proposal_registrations.py
       - name: Test proposal registration gate
@@ -87,12 +89,9 @@ jobs:
             > /tmp/chronik-outcome-consumer-report.json
           python -c "import json; r=json.load(open('/tmp/chronik-outcome-consumer-report.json', encoding='utf-8')); assert r['status']=='insufficient_evidence'; assert r['review_only'] is True; assert r['writes']==[]"
 
-      - name: Validate weight adjustment coherence against metarepo contract
+      - name: Validate weight adjustment coherence against the pinned metarepo mirror
         run: |
-          mkdir -p .ci
-          curl -fsSL https://raw.githubusercontent.com/heimgewebe/metarepo/a1984186a98a1e4214769f87649c5affc9686a53/contracts/policy.weight_adjustment.v1.schema.json \
-            -o .ci/policy.weight_adjustment.v1.schema.json
           python scripts/validate_weight_adjustment_coherence.py \
-            --schema .ci/policy.weight_adjustment.v1.schema.json
+            --schema contracts/mirrors/metarepo/policy.weight_adjustment.v1.schema.json
           python scripts/ola_circle_smoke.py \
-            --schema .ci/policy.weight_adjustment.v1.schema.json
+            --schema contracts/mirrors/metarepo/policy.weight_adjustment.v1.schema.json

--- a/Justfile
+++ b/Justfile
@@ -21,6 +21,8 @@ feedback-example:
 
 # ---- Validierung ----
 schema-validate: venv
+	. .venv/bin/activate && python scripts/validate_archive_readiness.py
+	. .venv/bin/activate && python -m pytest -q tests/test_archive_readiness.py
 	. .venv/bin/activate && python scripts/examples.py
 	. .venv/bin/activate && python scripts/validate_json.py contracts/policy.snapshot.schema.json /tmp/heimlern_snapshot.json
 	. .venv/bin/activate && python scripts/validate_json.py contracts/policy.feedback.schema.json /tmp/heimlern_feedback.json

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 >
 > Heimlern is frozen as implementation and design history. Its analyzers, proposal formats and examples remain available for audit and reference, but they are not a promoted evaluator, routing service, friction system, policy engine or runtime component. New feature development is out of scope unless a separately registered, non-circular usefulness experiment first establishes material operator value. See [Historical status](docs/historical-status.md).
 
+The machine-readable final archive gate is [`docs/archive-readiness.v1.json`](docs/archive-readiness.v1.json). It binds the merged HausKI compatibility freeze, exact external contract authorities, the preserved proposal-only boundary and the pre-archive GitHub inventory.
+
 ## Historical operator-ecosystem context
 
 Heimlern was implemented as a retrospective learning and policy-adaptation proposal engine. It could read Chronik history, outcomes, metrics and explicit feedback, then produce auditable learning reports or weight-adjustment proposals. It was never permitted to silently apply policy, own tasks, execute operations, or become the source of event history. Bureau owns commitments, Grabowski owns local execution, and Chronik owns history.

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -1,82 +1,22 @@
-# Contracts für heimlern (Snapshots & Feedback)
+# Heimlern contract archive
 
-Diese Verträge definieren das externe Austauschformat:
-- **PolicySnapshot**: Zustandsstand einer Policy (Arme, Zähler, Werte …)
-- **PolicyFeedback**: Rückmeldung zu einer Entscheidung (Reward, Notizen)
-- **Außensensor-Event**: Normalisierte JSON-Struktur für eingehende Sensor-Events
+This directory is preserved as implementation history. It is not an active contract authority. The exact classification and SHA-256 binding of every local JSON schema is recorded in `../docs/archive-readiness.v1.json`.
 
-Ziele:
-- Reproduzierbarkeit (Versionierung)
-- Strikte Validierung (keine schleichende Schema-Drift)
-- Tool-agnostisch (Rust, Python, Shell …)
+## Normative external mirrors
 
-## Contract Ownership & Architecture
+Only two repository copies are treated as exact, authority-bound mirrors:
 
-**Heimlern-eigene Schemas (in diesem Repo):**
+- `mirrors/metarepo/policy.weight_adjustment.v1.schema.json`, owned by `heimgewebe/metarepo`;
+- `mirrors/chronik/operator-routing-outcome-export-v1.schema.json`, owned by `heimgewebe/chronik`.
 
-Dieses Repo besitzt und verwaltet Schemas für Payloads, die heimlern selbst produziert:
-- `policy.snapshot.schema.json` - Policy-Zustand (heimlern → hausKI, chronik)
-- `policy.decision.schema.json` - Entscheidungsdokumentation (heimlern → hausKI, chronik)
-- `policy.feedback.schema.json` - Feedback zu Entscheidungen (hausKI → heimlern)
-- `aussen.event.schema.json` - Externe Sensor-Events (Sensoren → heimlern, hausKI)
+Each mirror has a neighboring pin containing the exact source repository, commit, path and digest. Heimlern does not own those contracts. CI validates the local pinned copies and performs no live schema download.
 
-**Konsumierte Contracts (Owner: metarepo):**
+## Historical local schemas
 
-Heimlern **konsumiert** folgende interne Heimgewebe-Contracts aus dem **metarepo**:
-- `decision.outcome.v1` - Retrospektive Bewertung von Entscheidungen (hausKI, chronik → heimlern)
-- `policy.weight_adjustment.v1` - Gewichtsanpassungsvorschläge (heimlern → hausKI)
+Top-level schemas in this directory are frozen historical references. Some have a current contract with the same filename in Metarepo but differ byte-for-byte; the archive manifest labels them `historical_divergent_copy`. `aussen.event.schema.json` is currently byte-identical to its Metarepo authority, but ownership still remains with Metarepo. Local-only learning and routing schemas are historical experiment formats and grant no runtime or routing authority.
 
-Die kanonischen Definitionen liegen im **heimgewebe/metarepo/contracts/**.
-Heimlern referenziert diese Schemas zur Compile-/Laufzeit, besitzt sie aber nicht.
+`operator.routing_outcome.v1.schema.json` remains pinned as the historical payload expected by the exact Chronik envelope mirror. That pin preserves replayability only; it does not keep Heimlern active.
 
-## Payload vs Event Envelope
+## Proposal-only boundary
 
-**Wichtig:** Die referenzierten Schemas definieren **Payload-Strukturen**, nicht Event-Envelopes.
-
-Wenn diese Daten über ein Event-System (z.B. chronik, plexer) transportiert werden, 
-werden sie in ein standardisiertes Envelope eingebettet mit Feldern wie:
-- `type`: Event-Typ
-- `source`: Quelle des Events
-- `payload`: Die hier definierten Strukturen
-- `ts`: Event-Zeitstempel
-- `id`: Event-ID
-
-Die Envelope-Spezifikation ist Teil der übergeordneten Event-Architektur und
-bleibt beim jeweiligen Transport-Owner. Für Routing-Outcomes konsumiert
-Heimlern den Chronik-Contract als exakten, digest-gepinnten Mirror unter
-`contracts/mirrors/chronik/`; daraus entsteht kein Contract-Eigentum.
-
-## Quickstart
-```sh
-just snapshot:example
-just feedback:example
-just schema:validate
-```
-
-## Schema-Übersicht
-
-**Schemas in diesem Repo (heimlern-owned):**
-
-| Schema | Zweck | Produzenten | Konsumenten |
-|--------|-------|-------------|-------------|
-| `policy.snapshot.schema.json` | Policy-Zustand persistieren | heimlern | hausKI, chronik |
-| `policy.decision.schema.json` | Entscheidungsdokumentation | heimlern | hausKI, chronik |
-| `policy.feedback.schema.json` | Feedback zu Entscheidungen | hausKI | heimlern |
-| `aussen.event.schema.json` | Externe Sensor-Events | Sensoren, APIs | heimlern, hausKI |
-
-**Konsumierte Schemas als exakte Mirrors (nicht Heimlern-owned):**
-
-| Schema | Zweck | Produzenten | Konsumenten |
-|--------|-------|-------------|-------------|
-| `decision.outcome.v1` | Retrospektive Outcome-Bewertung | hausKI, chronik | heimlern |
-| `policy.weight_adjustment.v1` | Gewichtsanpassungsvorschläge | heimlern | hausKI |
-
-Die Mirrors liegen mit Source-Revision, Source-Pfad, SHA-256 und Non-Claims
-unter `contracts/mirrors/`. Kanonisch bleiben Chronik beziehungsweise Metarepo.
-
-## Operator routing
-
-- `operator.routing_decision.v1.schema.json`: records one bounded operator routing choice before the result is known.
-- `operator.routing_outcome.v1.schema.json`: records the retrospective result, reward and redacted friction metrics.
-
-These files are offline-learning inputs only. They do not authorize live routing changes.
+The preserved examples and analyzers may validate historical data and produce review-only proposal candidates. They must retain `writes_production: false`, `writes: []`, no automatic policy or routing changes, no queue authority and no live Grabowski producer.

--- a/contracts/mirrors/metarepo/policy.weight_adjustment.v1.pin.json
+++ b/contracts/mirrors/metarepo/policy.weight_adjustment.v1.pin.json
@@ -3,7 +3,7 @@
   "authority": "mirror_only",
   "owner": "heimgewebe/metarepo",
   "source_repository": "heimgewebe/metarepo",
-  "source_revision": "10daa1c84469dce76e93cdc24c47c1dfc5e156d6",
+  "source_revision": "90fef7585b473ef499847ad92a21f76abd2b1c41",
   "source_path": "contracts/policy.weight_adjustment.v1.schema.json",
   "sha256": "5998e43de8465e55a133294c16231377cfd1c7d66a06bfab3d22f83d17170e78",
   "does_not_establish": [

--- a/docs/archive-readiness.v1.json
+++ b/docs/archive-readiness.v1.json
@@ -1,0 +1,205 @@
+{
+  "consumer_freeze": {
+    "diff_sha256": "d790aa1af2cb6c9bae9ac5f56110a027c54ebbe0ca0acacad27cbed211e2ccf1",
+    "head": "da03d620c25e762882251af493a00929570ca854",
+    "merge_commit": "4af4d397c67acefd3dc385393f1ef55b88adc097",
+    "pull_request": 759,
+    "repository": "heimgewebe/hausKI",
+    "status": "merged_and_green"
+  },
+  "does_not_establish": [
+    "github_archive_effect_completed",
+    "deletion_of_historical_branches",
+    "runtime_or_policy_authority",
+    "automatic_proposal_application",
+    "current_semantic_validity_of_historical_local_contracts",
+    "permission_for_new_feature_development"
+  ],
+  "kind": "heimlern_archive_readiness",
+  "local_contracts": [
+    {
+      "canonical_authority": {
+        "path": "contracts/aussen.event.schema.json",
+        "repository": "heimgewebe/metarepo",
+        "revision": "90fef7585b473ef499847ad92a21f76abd2b1c41",
+        "sha256": "2410e7ccd2a94271d6b292d4e8df5a4190a111376f26ae509901c8995a888f37"
+      },
+      "classification": "canonical_mirror",
+      "local_path": "contracts/aussen.event.schema.json",
+      "local_sha256": "2410e7ccd2a94271d6b292d4e8df5a4190a111376f26ae509901c8995a888f37"
+    },
+    {
+      "canonical_authority": {
+        "path": "contracts/metrics.snapshot.schema.json",
+        "repository": "heimgewebe/metarepo",
+        "revision": "90fef7585b473ef499847ad92a21f76abd2b1c41",
+        "sha256": "1b1de44ea326ce8de36da6fc6d8f2da0abe279df8c47ab10e58ddc2cf604b914"
+      },
+      "classification": "historical_divergent_copy",
+      "local_path": "contracts/metrics.snapshot.schema.json",
+      "local_sha256": "e04bb990ea37997ab8b04aa931d065743bf431dd00c9ae2316672b40aaf47ce7"
+    },
+    {
+      "canonical_authority": {
+        "path": "contracts/policy.decision.schema.json",
+        "repository": "heimgewebe/metarepo",
+        "revision": "90fef7585b473ef499847ad92a21f76abd2b1c41",
+        "sha256": "2de890b578285100f57839d6fe7f8dd43326fa9c1c7c84759dd5a3604c025bce"
+      },
+      "classification": "historical_divergent_copy",
+      "local_path": "contracts/policy.decision.schema.json",
+      "local_sha256": "a6c193d33f006b959036dce189cb2b97cfbdbeda2ae5fbdb08aae526356c52b9"
+    },
+    {
+      "canonical_authority": {
+        "path": "contracts/policy.feedback.schema.json",
+        "repository": "heimgewebe/metarepo",
+        "revision": "90fef7585b473ef499847ad92a21f76abd2b1c41",
+        "sha256": "b718aedfb33d00330602cdb5fe1168693c0137df87f6afcf4e0bf33d8b0821b3"
+      },
+      "classification": "historical_divergent_copy",
+      "local_path": "contracts/policy.feedback.schema.json",
+      "local_sha256": "cb331af69325c6b10bd1910b7eb2a4d6f6c13d6c9517706b2b6b6741663e620b"
+    },
+    {
+      "canonical_authority": {
+        "path": "contracts/policy.snapshot.schema.json",
+        "repository": "heimgewebe/metarepo",
+        "revision": "90fef7585b473ef499847ad92a21f76abd2b1c41",
+        "sha256": "6a51ba574f9d0575b8c6298eda4b08a6f483035502a2d5511f5f8fb831e5fbe7"
+      },
+      "classification": "historical_divergent_copy",
+      "local_path": "contracts/policy.snapshot.schema.json",
+      "local_sha256": "4a3e8cf8d51c58ac6e88a744e2bb139a5ee36f1f8ad39d6da8b815f2e355a454"
+    },
+    {
+      "canonical_authority": {
+        "path": "contracts/heimlern.ingest.state.schema.json",
+        "repository": "heimgewebe/metarepo",
+        "revision": "90fef7585b473ef499847ad92a21f76abd2b1c41",
+        "sha256": "accd33e387f954d2dfc2e96b96e2941847e275830c01fe8142fc44618b2c089f"
+      },
+      "classification": "historical_divergent_copy",
+      "local_path": "ops/schemas/heimlern.ingest.state.schema.json",
+      "local_sha256": "f155095517e8f0006e1e543692603531c2e61436d58d33d6372be41bee93c8db"
+    },
+    {
+      "canonical_authority": null,
+      "classification": "historical_local_only",
+      "local_path": "contracts/learning.proposal.registration.v1.schema.json",
+      "local_sha256": "e76d565c5f1b0aed8f74bf6c1ae7a4b03cee168aeef1198b0a1378879fd4878d"
+    },
+    {
+      "canonical_authority": null,
+      "classification": "historical_local_only",
+      "local_path": "contracts/learning_path.schema.json",
+      "local_sha256": "a185ef2a263309cb8e17c938f6a477c7d1d9c44ce6cd2c06e85e3a3eb5a34a0c"
+    },
+    {
+      "canonical_authority": null,
+      "classification": "historical_local_only",
+      "local_path": "contracts/operator.routing_decision.v1.schema.json",
+      "local_sha256": "046160abe104602f98ec34c58a57ac6f41b65cd25e65e4afed3f6ac3fbd2be57"
+    },
+    {
+      "canonical_authority": {
+        "path": "contracts/operator.routing_outcome.v1.schema.json",
+        "repository": "heimgewebe/heimlern",
+        "revision": "6d70e4900377c92b540d07bd6b71fe36677c2ba5",
+        "sha256": "cff1f19814d33dd0ba084b3b5d9e2d4b6c36b1276dab35c3256912b5c457712d"
+      },
+      "classification": "historical_payload_pin",
+      "local_path": "contracts/operator.routing_outcome.v1.schema.json",
+      "local_sha256": "cff1f19814d33dd0ba084b3b5d9e2d4b6c36b1276dab35c3256912b5c457712d"
+    }
+  ],
+  "normative_mirrors": [
+    {
+      "authority": {
+        "path": "contracts/policy.weight_adjustment.v1.schema.json",
+        "repository": "heimgewebe/metarepo",
+        "revision": "90fef7585b473ef499847ad92a21f76abd2b1c41",
+        "sha256": "5998e43de8465e55a133294c16231377cfd1c7d66a06bfab3d22f83d17170e78"
+      },
+      "local_schema": "contracts/mirrors/metarepo/policy.weight_adjustment.v1.schema.json",
+      "local_sha256": "5998e43de8465e55a133294c16231377cfd1c7d66a06bfab3d22f83d17170e78",
+      "pin": "contracts/mirrors/metarepo/policy.weight_adjustment.v1.pin.json"
+    },
+    {
+      "authority": {
+        "path": "docs/chronik/operator-routing-outcome-export-v1.schema.json",
+        "repository": "heimgewebe/chronik",
+        "revision": "de1287423f3156cfae86c3cae6f4538732356c01",
+        "sha256": "d7c3709caaadcf599321f5abef77064631bd1a7b534346488baec595f65b3c91"
+      },
+      "local_schema": "contracts/mirrors/chronik/operator-routing-outcome-export-v1.schema.json",
+      "local_sha256": "d7c3709caaadcf599321f5abef77064631bd1a7b534346488baec595f65b3c91",
+      "pin": "contracts/mirrors/chronik/operator-routing-outcome-export-v1.pin.json"
+    }
+  ],
+  "offline_proposal_only_boundary": {
+    "file_bindings": [
+      {
+        "path": "crates/heimlern-cli/src/main.rs",
+        "sha256": "c09b582ace201af0eb87b77a170a650d0617710f91ee74c47c1e8888f0bf2249"
+      },
+      {
+        "path": "scripts/ola_probe.py",
+        "sha256": "ebcc6800cffd18014d5abd131abcbc461c3f8fe125579097fa05e643a3e2fe56"
+      },
+      {
+        "path": "scripts/ola_circle_smoke.py",
+        "sha256": "287e2f7156cd78c1f4c7de53144d6ffeca8ae385988fee1e18c795ce4d70af21"
+      },
+      {
+        "path": "scripts/chronik_outcome_consumer.py",
+        "sha256": "f6f66955386f8cfa649aaf6d46c35d639c04330e9b7f8dd16daa38a8c878f04a"
+      },
+      {
+        "path": "contracts/learning_path.schema.json",
+        "sha256": "a185ef2a263309cb8e17c938f6a477c7d1d9c44ce6cd2c06e85e3a3eb5a34a0c"
+      },
+      {
+        "path": "contracts/learning.proposal.registration.v1.schema.json",
+        "sha256": "e76d565c5f1b0aed8f74bf6c1ae7a4b03cee168aeef1198b0a1378879fd4878d"
+      }
+    ],
+    "required_properties": [
+      "writes_production_false",
+      "writes_empty",
+      "no_auto_policy",
+      "no_auto_routing",
+      "no_queue_authority",
+      "no_runtime_authority",
+      "no_live_grabowski_producer"
+    ],
+    "status": "preserved"
+  },
+  "prearchive_github_snapshot": {
+    "branch_count": 181,
+    "branch_policy": "preserve_all_historical_branches; no bulk deletion",
+    "default_branch": "main",
+    "default_branch_commit": "d0a5d1bf26c9a5f555b7541d97fadb27a7cf9b31",
+    "is_archived": false,
+    "observed_at": "2026-07-20T09:06:00+02:00",
+    "open_issues": 0,
+    "open_pull_requests": 0,
+    "releases": 0
+  },
+  "proposal_inventory": {
+    "active_registration_count": 0,
+    "allowed_files": [
+      "proposals/README.md",
+      "proposals/_template.json"
+    ]
+  },
+  "protobuf_inventory": {
+    "classification": "none_present; documentation mentions are historical and non-normative",
+    "count": 0
+  },
+  "repository": "heimgewebe/heimlern",
+  "repository_base_commit": "d0a5d1bf26c9a5f555b7541d97fadb27a7cf9b31",
+  "schema_version": 1,
+  "status": "ready_for_archive_effect",
+  "target_state": "archived_reference"
+}

--- a/docs/historical-status.md
+++ b/docs/historical-status.md
@@ -39,3 +39,16 @@ Reactivation requires a new, separately registered experiment that:
 6. is reviewed and adopted outside this repository before implementation work begins.
 
 Absent that evidence, only preservation, security fixes and documentation corrections are in scope.
+
+## Final archive readiness
+
+The final archive declaration is machine-readable in `docs/archive-readiness.v1.json` and validated by `scripts/validate_archive_readiness.py`. It records:
+
+- HausKI PR #759, merged as `4af4d397c67acefd3dc385393f1ef55b88adc097`, which proves that the remaining compatibility crates are local, digest-bound and disabled by default;
+- zero open Heimlern pull requests, issues, releases and active proposal registrations at the pre-archive readback;
+- preservation of all 181 historical branches rather than destructive bulk cleanup;
+- exact Metarepo and Chronik mirror commits and SHA-256 values;
+- explicit classification of divergent repository-local schemas as historical references, not current contract authority;
+- no protobuf definitions and no live Grabowski producer, queue, routing or policy authority.
+
+The declaration is a precondition for the GitHub archive effect. It does not itself prove that GitHub has applied that effect; the post-effect readback belongs in the operator registry and ecosystem projections.

--- a/scripts/validate_archive_readiness.py
+++ b/scripts/validate_archive_readiness.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Validate the immutable Heimlern archive-readiness declaration."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+MANIFEST = ROOT / "docs/archive-readiness.v1.json"
+
+
+class ArchiveReadinessError(RuntimeError):
+    """Raised when the declared archive boundary no longer holds."""
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _require_file(root: Path, path_text: str, expected_sha256: str) -> None:
+    path = root / path_text
+    if not path.is_file():
+        raise ArchiveReadinessError(f"missing bound file: {path_text}")
+    if _sha256(path) != expected_sha256:
+        raise ArchiveReadinessError(f"bound file changed: {path_text}")
+
+
+def _validate_proposal_inventory(root: Path, inventory: dict[str, Any]) -> None:
+    proposal_files = {
+        path.relative_to(root).as_posix()
+        for path in (root / "proposals").rglob("*")
+        if path.is_file()
+    }
+    expected = set(inventory["allowed_files"])
+    if proposal_files != expected:
+        unexpected = sorted(proposal_files - expected)
+        missing = sorted(expected - proposal_files)
+        raise ArchiveReadinessError(
+            f"proposal inventory changed: unexpected={unexpected}, missing={missing}"
+        )
+    if inventory["active_registration_count"] != 0:
+        raise ArchiveReadinessError("active proposal registrations are declared")
+
+
+def _validate_mirror(root: Path, entry: dict[str, Any]) -> None:
+    _require_file(root, entry["local_schema"], entry["local_sha256"])
+    pin = json.loads((root / entry["pin"]).read_text(encoding="utf-8"))
+    authority = entry["authority"]
+    fields = {
+        "source_repository": "repository",
+        "source_revision": "revision",
+        "source_path": "path",
+        "sha256": "sha256",
+    }
+    for pin_key, authority_key in fields.items():
+        if pin.get(pin_key) != authority[authority_key]:
+            raise ArchiveReadinessError(
+                f"mirror pin mismatch: {entry['pin']}:{pin_key}"
+            )
+
+
+def validate() -> dict[str, Any]:
+    data = json.loads(MANIFEST.read_text(encoding="utf-8"))
+    if data.get("schema_version") != 1:
+        raise ArchiveReadinessError("unsupported archive-readiness schema")
+    if data.get("status") != "ready_for_archive_effect":
+        raise ArchiveReadinessError("archive readiness status is invalid")
+
+    snapshot = data["prearchive_github_snapshot"]
+    if snapshot["is_archived"] is not False:
+        raise ArchiveReadinessError("prearchive snapshot is not prearchive")
+    if snapshot["open_pull_requests"] != 0 or snapshot["open_issues"] != 0:
+        raise ArchiveReadinessError("prearchive snapshot contains open work")
+    if data["consumer_freeze"]["status"] != "merged_and_green":
+        raise ArchiveReadinessError("HausKI consumer freeze is not merged and green")
+
+    for entry in data["normative_mirrors"]:
+        _validate_mirror(ROOT, entry)
+    for entry in data["local_contracts"]:
+        _require_file(ROOT, entry["local_path"], entry["local_sha256"])
+
+    expected_top = {
+        Path(entry["local_path"]).as_posix()
+        for entry in data["local_contracts"]
+        if Path(entry["local_path"]).parent == Path("contracts")
+    }
+    actual_top = {
+        path.relative_to(ROOT).as_posix()
+        for path in (ROOT / "contracts").glob("*.json")
+    }
+    if actual_top != expected_top:
+        raise ArchiveReadinessError("top-level contract inventory changed")
+
+    if list(ROOT.rglob("*.proto")):
+        raise ArchiveReadinessError("protobuf definitions unexpectedly present")
+
+    boundary = data["offline_proposal_only_boundary"]
+    if boundary["status"] != "preserved":
+        raise ArchiveReadinessError("offline proposal-only boundary is not preserved")
+    for entry in boundary["file_bindings"]:
+        _require_file(ROOT, entry["path"], entry["sha256"])
+
+    _validate_proposal_inventory(ROOT, data["proposal_inventory"])
+
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    historical = (ROOT / "docs/historical-status.md").read_text(encoding="utf-8")
+    if "frozen as implementation and design history" not in readme:
+        raise ArchiveReadinessError("README historical boundary missing")
+    if "frozen historical reference" not in historical:
+        raise ArchiveReadinessError("historical status boundary missing")
+
+    return {
+        "status": "valid",
+        "kind": data["kind"],
+        "normative_mirrors": len(data["normative_mirrors"]),
+        "historical_contracts": len(data["local_contracts"]),
+        "protobuf_count": 0,
+        "active_proposals": 0,
+        "consumer_freeze_merge": data["consumer_freeze"]["merge_commit"],
+    }
+
+
+def main() -> int:
+    try:
+        result = validate()
+    except (ArchiveReadinessError, KeyError, OSError, ValueError, json.JSONDecodeError) as exc:
+        print(json.dumps({"status": "invalid", "error": str(exc)}, sort_keys=True))
+        return 1
+    print(json.dumps(result, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_archive_readiness.py
+++ b/tests/test_archive_readiness.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/validate_archive_readiness.py"
+
+
+def _load_validator():
+    spec = importlib.util.spec_from_file_location("validate_archive_readiness", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_current_archive_readiness_is_valid() -> None:
+    module = _load_validator()
+    result = module.validate()
+    assert result["status"] == "valid"
+    assert result["consumer_freeze_merge"] == "4af4d397c67acefd3dc385393f1ef55b88adc097"
+    assert result["active_proposals"] == 0
+
+
+def test_changed_bound_contract_fails_closed(tmp_path: Path, monkeypatch) -> None:
+    module = _load_validator()
+    manifest = json.loads(module.MANIFEST.read_text(encoding="utf-8"))
+    manifest["local_contracts"][0]["local_sha256"] = "0" * 64
+    altered = tmp_path / "archive-readiness.json"
+    altered.write_text(json.dumps(manifest), encoding="utf-8")
+    monkeypatch.setattr(module, "MANIFEST", altered)
+
+    with pytest.raises(module.ArchiveReadinessError, match="bound file changed"):
+        module.validate()
+
+
+def test_unknown_proposal_file_fails_closed(tmp_path: Path) -> None:
+    module = _load_validator()
+    proposals = tmp_path / "proposals"
+    proposals.mkdir()
+    (proposals / "README.md").write_text("history", encoding="utf-8")
+    (proposals / "_template.json").write_text("{}", encoding="utf-8")
+    (proposals / "active.json").write_text("{}", encoding="utf-8")
+    inventory = {
+        "active_registration_count": 0,
+        "allowed_files": ["proposals/README.md", "proposals/_template.json"],
+    }
+
+    with pytest.raises(module.ArchiveReadinessError, match="unexpected=.*active.json"):
+        module._validate_proposal_inventory(tmp_path, inventory)


### PR DESCRIPTION
## Zweck

Deklariert Heimlern als prüfbare historische Referenz und schafft die letzte technische Voraussetzung für den GitHub-Archiveffekt.

## Belegte Voraussetzungen

- HausKI PR #759 ist als Mergecommit `4af4d397c67acefd3dc385393f1ef55b88adc097` gemergt; die verbliebenen Kompatibilitäts-Crates sind lokal, digestgebunden und standardmäßig deaktiviert.
- GitHub-Readback vor dem Effekt: 0 offene PRs, 0 offene Issues, 0 Releases, 181 historische Branches.
- Die Branches werden bewahrt; es erfolgt keine pauschale Löschung.
- Zwei normative Mirrors sind an exakte Metarepo-/Chronik-Commits und SHA-256-Werte gebunden.
- Gleichnamige, aber abweichende lokale Schemas sind ausdrücklich historische Kopien und keine aktuelle Autorität.
- Es existieren keine Protobuf-Definitionen und keine aktiven Proposal-Registrierungen.
- Die Offline-Grenze bleibt `writes_production=false`, `writes=[]`, ohne Routing-, Queue-, Runtime- oder Policy-Autorität.

## Änderungen

- `docs/archive-readiness.v1.json` als maschinenlesbarer Abschlussvertrag
- fail-closed Validator und drei negative/positive Tests
- CI- und Just-Integration
- Metarepo-Pin auf live verifizierten Commit `90fef758…` aktualisiert
- letzter CI-Live-Download durch den exakt gepinnten lokalen Mirror ersetzt
- README, historische Statusseite und Vertragsdokumentation auf Archivrolle korrigiert

## Prüfung

- Archivvalidator: PASS
- Archivtests: 3 PASS
- vollständige Python-Tests: PASS — Receipt `472d657218abf7a0adf20f0d0a6403d5738a027daac225beb539729c3be2151f`
- Rust fmt: PASS — Receipt `55a410ce8a117fe3c46ae7f14771ffd5fb4150234276856f08bd1ea1526eb895`
- Clippy: PASS — Receipt `db2b05196831e289e00f1f4a61757005568e2d8df6177cee2de4f8e22a5e87aa`
- vollständige Rust-Tests: PASS — Receipt `05025672615ed99b67e2f0e620a79a5881a240a28bf51b1eaeea15db137abb79`
- Schema-Samples, Weight-Adjustment-Kohärenz und OLA review-only circle: PASS
- Workflow-YAML und Python-Kompilierung: PASS

## Beweisgrenze

Dieser PR beweist die Bereitschaft, nicht den bereits ausgeführten GitHub-Archiveffekt. Der Effekt wird erst nach Merge, erneutem Remote-Readback und exakter Mergecommit-Bindung ausgeführt und anschließend separat zurückgelesen.

## Diffbindung

- Head: `e97aba4`
- Basis: `d0a5d1bf26c9a5f555b7541d97fadb27a7cf9b31`
- Diff-SHA-256: `fd705b6f0b39f898cfc5d19b84854d05534cec36094a6d3487ef4762e2ae45d0`

Teil von `OPERATOR-ECOSYSTEM-REDUNDANCY-V1-T036`.
